### PR TITLE
Make deadletter setup optional & customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ exchange and has a deadletter exchange set to `gen_rmq_exchange.deadletter`
 * every `handle_message` callback will executed in separate process. This can be disabled by setting `concurrency: false` in `init` callback
 * on failed rabbitmq connection it will wait for a bit and then reconnect
 
+Optionally, you can:
+* specify queue ttl with `queue_ttl` attribute
+* disable deadletter setup by setting `deadletter` attribute to `false`
+* define custom names for deadletter queue / exchange by specifying `deadletter_queue` / `deadletter_exchange` attributes
+
 For all available options please check [consumer documentation](lib/consumer.ex).
 
 ### Publisher

--- a/test/gen_rmq_consumer_test.exs
+++ b/test/gen_rmq_consumer_test.exs
@@ -7,6 +7,8 @@ defmodule GenRMQ.ConsumerTest do
   alias TestConsumer.Default
   alias TestConsumer.WithoutConcurrency
   alias TestConsumer.WithoutReconnection
+  alias TestConsumer.WithoutDeadletter
+  alias TestConsumer.WithoutCustomDeadletter
 
   @uri "amqp://guest:guest@localhost:5672"
   @exchange "gen_rmq_in_exchange"
@@ -24,15 +26,14 @@ defmodule GenRMQ.ConsumerTest do
 
     test "should return consumer config" do
       {:ok, config} = GenRMQ.Consumer.init(%{module: Default})
-
       assert Default.init() == config[:config]
     end
 
     test "should receive a message", context do
       message = %{"msg" => "some message"}
-
       {:ok, _} = Agent.start_link(fn -> MapSet.new() end, name: Default)
       {:ok, _} = GenRMQ.Consumer.start_link(Default, name: :consumer)
+
       publish_message(context[:rabbit_conn], context[:exchange], Poison.encode!(message))
 
       Assert.repeatedly(fn ->
@@ -40,38 +41,64 @@ defmodule GenRMQ.ConsumerTest do
       end)
     end
 
+    test "should reject a message", context do
+      message = "reject"
+      {:ok, consumer_pid} = GenRMQ.Consumer.start_link(Default, name: :consumer)
+      state = :sys.get_state(consumer_pid)
+
+      publish_message(context[:rabbit_conn], context[:exchange], Poison.encode!(message))
+
+      Assert.repeatedly(fn ->
+        assert queue_count(context[:rabbit_conn], "#{state.config[:queue]}_error") == {:ok, 1}
+      end)
+    end
+
+    test "should reconnect after connection failure", context do
+      message = %{"msg" => "disconnect"}
+      {:ok, _} = Agent.start_link(fn -> MapSet.new() end, name: Default)
+      {:ok, consumer_pid} = GenRMQ.Consumer.start_link(Default, name: :consumer)
+      state = :sys.get_state(consumer_pid)
+
+      AMQP.Connection.close(state.conn)
+      publish_message(context[:rabbit_conn], context[:exchange], Poison.encode!(message))
+
+      Assert.repeatedly(fn ->
+        assert Agent.get(Default, fn set -> message in set end) == true
+      end)
+    end
+
+    test "should terminate after queue deletion" do
+      {:ok, consumer_pid} = GenRMQ.Consumer.start_link(Default, name: :consumer)
+      state = :sys.get_state(consumer_pid)
+
+      AMQP.Queue.delete(state.out, state[:config][:queue])
+
+      Assert.repeatedly(fn ->
+        assert Process.alive?(consumer_pid) == false
+        assert Process.whereis(Default) == nil
+      end)
+    end
+  end
+
+  describe "GenRMQ.Consumer with concurrency disabled" do
     test "should receive a message and handle it in the same consumer process", context do
       message = %{"msg" => "handled in the same process"}
-
       {:ok, _} = Agent.start_link(fn -> MapSet.new() end, name: WithoutConcurrency)
       {:ok, pid} = GenRMQ.Consumer.start_link(WithoutConcurrency, name: :consumer_no_concurrency)
+
       publish_message(context[:rabbit_conn], context[:exchange], Poison.encode!(message))
 
       Assert.repeatedly(fn ->
         assert Agent.get(WithoutConcurrency, fn set -> {message, pid} in set end) == true
       end)
     end
+  end
 
-    test "should reconnect after connection failure", context do
-      message = %{"msg" => "disconnect"}
-
-      {:ok, _} = Agent.start_link(fn -> MapSet.new() end, name: Default)
-      {:ok, consumer_pid} = GenRMQ.Consumer.start_link(Default, name: :consumer)
-
-      state = :sys.get_state(consumer_pid)
-      AMQP.Connection.close(state.conn)
-
-      publish_message(context[:rabbit_conn], context[:exchange], Poison.encode!(message))
-
-      Assert.repeatedly(fn ->
-        assert Agent.get(Default, fn set -> message in set end) == true
-      end)
-    end
-
-    test "should terminate after connection failure when reconnection disabled" do
+  describe "GenRMQ.Consumer with reconnection disabled" do
+    test "should terminate after connection failure" do
       {:ok, consumer_pid} = GenRMQ.Consumer.start_link(WithoutReconnection, name: :consumer_no_reconnection)
-
       state = :sys.get_state(consumer_pid)
+
       AMQP.Connection.close(state.conn)
 
       Assert.repeatedly(fn ->
@@ -79,16 +106,32 @@ defmodule GenRMQ.ConsumerTest do
         assert Process.whereis(WithoutReconnection) == nil
       end)
     end
+  end
 
-    test "should terminate after queue deletion" do
-      {:ok, consumer_pid} = GenRMQ.Consumer.start_link(Default, name: :consumer)
-
+  describe "GenRMQ.Consumer with custom deadletter setup" do
+    test "should skip deadletter setup", context do
+      message = %{"msg" => "some message"}
+      {:ok, consumer_pid} = GenRMQ.Consumer.start_link(WithoutDeadletter, name: :consumer_no_deadletter)
       state = :sys.get_state(consumer_pid)
-      AMQP.Queue.delete(state.out, state[:config][:queue])
+
+      publish_message(context[:rabbit_conn], state.config[:exchange], Poison.encode!(message))
 
       Assert.repeatedly(fn ->
-        assert Process.alive?(consumer_pid) == false
-        assert Process.whereis(Default) == nil
+        assert Process.alive?(consumer_pid) == true
+        assert queue_count(context[:rabbit_conn], "#{state.config[:queue]}_error") == {:error, :not_found}
+      end)
+    end
+
+    test "should deadletter a message to a custom queue", context do
+      message = %{"msg" => "some message"}
+      {:ok, consumer_pid} = GenRMQ.Consumer.start_link(WithoutCustomDeadletter, name: :consumer_custom_deadletter)
+      state = :sys.get_state(consumer_pid)
+
+      publish_message(context[:rabbit_conn], state.config[:exchange], Poison.encode!(message))
+
+      Assert.repeatedly(fn ->
+        assert Process.alive?(consumer_pid) == true
+        assert queue_count(context[:rabbit_conn], "dl_queue") == {:ok, 1}
       end)
     end
   end


### PR DESCRIPTION
Solves https://github.com/meltwater/gen_rmq/issues/6

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
