### PR TITLE
Allow writing to metadata fields in publisher

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -11,8 +11,8 @@ defmodule GenRMQ.Publisher do
 
   # list of fields permitted in message metadata at top level
   @metadata_fields :P_basic
-    |> Record.extract(from_lib: "rabbit_common/include/rabbit_framing.hrl")
-    |> Keyword.keys()
+                   |> Record.extract(from_lib: "rabbit_common/include/rabbit_framing.hrl")
+                   |> Keyword.keys()
 
   ##############################################################################
   # GenRMQ.Publisher callbacks
@@ -160,7 +160,6 @@ defmodule GenRMQ.Publisher do
         connect(state)
     end
   end
-
 
   # Put standard metadata fields to top level, everything else into headers
   defp merge_metadata(base, custom) do

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -87,6 +87,7 @@ defmodule GenRMQ.PublisherTest do
       message = %{"msg" => "msg"}
 
       {:ok, _} = GenRMQ.Publisher.start_link(TestPublisher, name: TestPublisher)
+
       GenRMQ.Publisher.publish(
         TestPublisher,
         Poison.encode!(message),
@@ -94,21 +95,21 @@ defmodule GenRMQ.PublisherTest do
         message_id: "message_id_1",
         correlation_id: "correlation_id_1",
         header1: "value"
-        )
+      )
 
-        Assert.repeatedly(fn -> assert out_queue_count(context) >= 1 end)
-        {:ok, received_message, meta} = get_message_from_queue(context)
+      Assert.repeatedly(fn -> assert out_queue_count(context) >= 1 end)
+      {:ok, received_message, meta} = get_message_from_queue(context)
 
-        assert message == received_message
-        assert meta[:message_id] == "message_id_1"
-        assert meta[:correlation_id] == "correlation_id_1"
-        refute meta[:header1]
+      assert message == received_message
+      assert meta[:message_id] == "message_id_1"
+      assert meta[:correlation_id] == "correlation_id_1"
+      refute meta[:header1]
 
-        assert [
-            {"message_id", :longstr, "message_id_1"},
-            {"correlation_id", :longstr, "correlation_id_1"},
-            {"header1", :longstr, "value"}
-          ] == meta[:headers]
+      assert [
+               {"message_id", :longstr, "message_id_1"},
+               {"correlation_id", :longstr, "correlation_id_1"},
+               {"header1", :longstr, "value"}
+             ] == meta[:headers]
     end
 
     test "should reconnect after connection failure", context do

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -105,11 +105,7 @@ defmodule GenRMQ.PublisherTest do
       assert meta[:correlation_id] == "correlation_id_1"
       refute meta[:header1]
 
-      assert [
-               {"message_id", :longstr, "message_id_1"},
-               {"correlation_id", :longstr, "correlation_id_1"},
-               {"header1", :longstr, "value"}
-             ] == meta[:headers]
+      assert [{"header1", :longstr, "value"}] == meta[:headers]
     end
 
     test "should reconnect after connection failure", context do

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -83,6 +83,34 @@ defmodule GenRMQ.PublisherTest do
       assert [{"header1", :longstr, "value"}] == meta[:headers]
     end
 
+    test "should override standard metadata fields from headers", context do
+      message = %{"msg" => "msg"}
+
+      {:ok, _} = GenRMQ.Publisher.start_link(TestPublisher, name: TestPublisher)
+      GenRMQ.Publisher.publish(
+        TestPublisher,
+        Poison.encode!(message),
+        "some.routing.key",
+        message_id: "message_id_1",
+        correlation_id: "correlation_id_1",
+        header1: "value"
+        )
+
+        Assert.repeatedly(fn -> assert out_queue_count(context) >= 1 end)
+        {:ok, received_message, meta} = get_message_from_queue(context)
+
+        assert message == received_message
+        assert meta[:message_id] == "message_id_1"
+        assert meta[:correlation_id] == "correlation_id_1"
+        refute meta[:header1]
+
+        assert [
+            {"message_id", :longstr, "message_id_1"},
+            {"correlation_id", :longstr, "correlation_id_1"},
+            {"header1", :longstr, "value"}
+          ] == meta[:headers]
+    end
+
     test "should reconnect after connection failure", context do
       message = %{"msg" => "pub_disc"}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A lot of software in our organization relies on correctly set correlation IDs and other fields in Rabbit message metadata. Current support for metadata in GenRMQ is limited:

* set `app_id` to a static value per publisher
* set any values to `headers` on per-message basis

This proposed change allows to set metadata fields like `message_id` or `correlation_id` when publishing messages via the `headers` argument of `GenRMQ.Publisher.publish/4`.
* Any field from `headers` that is allowed in metadata as per `rabbit_common` will also be included there.
* `app_id`, `timestamp` and `content_type` will be overridden with defaults from `base_metadata/1`.

This change adds new fields to the metadata while preserving both default metadata field behaviour and the header key/values, so it is assumed to be a non-breaking change.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [x] I have added unit tests to cover my changes.
- [x] I have not degraded the code quality of this repo.
- [x] I have updated the documentation accordingly

I would also propose to rename the `headers` parameter of `GenRMQ.Publisher.publish/4` to `metadata`, but I am not sure it will break any existing software on your side (presumably it shouldn't).