### PR TITLE
Revert otp21 fix and make examples easier to run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,11 @@
 language: elixir
 elixir:
+  - 1.5
   - 1.6
 
 otp_release:
+  - 19.0
   - 20.0
-  - 21.0
-
-matrix:
-  include:
-    - elixir: '1.5'
-      otp_release:
-        - '19.0'
-    - elixir: '1.5'
-      otp_release:
-        - '20.0'
 
 sudo: required
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The project currently provides the following functionality:
 
 ~~~elixir
 def deps do
-  [{:gen_rmq, "~> 1.0.1"}]
+  [{:gen_rmq, "~> 1.0.0"}]
 end
 ~~~
 

--- a/examples/consumer.ex
+++ b/examples/consumer.ex
@@ -1,4 +1,4 @@
-defmodule MyApp.ExampleConsumer do
+defmodule ExampleConsumer do
   @moduledoc """
   Example GenRMQ.Consumer implementation
   """
@@ -6,7 +6,6 @@ defmodule MyApp.ExampleConsumer do
 
   require Logger
 
-  alias Mix.Project
   alias GenRMQ.Message
 
   ##############################################################################
@@ -32,11 +31,18 @@ defmodule MyApp.ExampleConsumer do
   ##############################################################################
 
   def init() do
-    Application.get_env(:my_app, __MODULE__)
+    [
+      queue: "example_queue",
+      exchange: "example_exchange",
+      routing_key: "routing_key.#",
+      prefetch_count: "10",
+      uri: "amqp://guest:guest@localhost:5672"
+    ]
   end
 
   def handle_message(%Message{} = message) do
-    # Implement your logic here.
+    Logger.info("Received message: #{inspect(message)}")
+    ack(message)
   rescue
     exception ->
       Logger.error(Exception.format(:error, exception, System.stacktrace()))
@@ -45,8 +51,6 @@ defmodule MyApp.ExampleConsumer do
 
   def consumer_tag() do
     {:ok, hostname} = :inet.gethostname()
-    app = Project.config() |> Keyword.get(:app)
-    version = Project.config() |> Keyword.get(:version)
-    "#{hostname}-#{app}-#{version}-consumer"
+    "#{hostname}-example-consumer"
   end
 end

--- a/examples/publisher.ex
+++ b/examples/publisher.ex
@@ -1,4 +1,4 @@
-defmodule MyApp.ExamplePublisher do
+defmodule ExamplePublisher do
   @moduledoc """
   Example GenRMQ.Publisher implementation
   """
@@ -11,12 +11,15 @@ defmodule MyApp.ExamplePublisher do
     GenRMQ.Publisher.start_link(__MODULE__, name: __MODULE__)
   end
 
-  def publish_message(message) do
+  def publish_message(message, routing_key) do
     Logger.info("Publishing message #{inspect(message)}")
-    GenRMQ.Publisher.publish(__MODULE__, message)
+    GenRMQ.Publisher.publish(__MODULE__, message, routing_key)
   end
 
   def init() do
-    Application.get_env(:my_app, __MODULE__)
+    [
+      exchange: "example_exchange",
+      uri: "amqp://guest:guest@localhost:5672"
+    ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule GenRMQ.Mixfile do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.0.0"
 
   def project do
     [
@@ -38,10 +38,6 @@ defmodule GenRMQ.Mixfile do
   defp deps do
     [
       {:amqp, "~> 1.0"},
-      # Fixes:
-      # https://github.com/pma/amqp/issues/99
-      # https://github.com/rabbitmq/rabbitmq-common/issues/269
-      {:ranch_proxy_protocol, "~> 2.0", override: true},
       {:credo, "~> 0.8", only: :dev},
       {:excoveralls, "~> 0.9.1", only: :test},
       {:poison, "~> 3.1", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "rabbit_common": {:hex, :rabbit_common, "3.7.7", "c0afdf060c091f43d7d6f58889978a074a7a8e28a5e89b9e40c6a474ba295011", [:make, :rebar3], [{:jsx, "2.8.2", [hex: :jsx, repo: "hexpm", optional: false]}, {:lager, "3.6.3", [hex: :lager, repo: "hexpm", optional: false]}, {:ranch, "1.5.0", [hex: :ranch, repo: "hexpm", optional: false]}, {:ranch_proxy_protocol, "1.5.0", [hex: :ranch_proxy_protocol, repo: "hexpm", optional: false]}, {:recon, "2.3.2", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [:rebar3], [], "hexpm"},
-  "ranch_proxy_protocol": {:hex, :ranch_proxy_protocol, "2.0.0", "623c732025f9d66d123a8ccc1735e5f43d7eb9b20aa09457c9609ef05f7e8ace", [:rebar3], [{:ranch, "1.5.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "ranch_proxy_protocol": {:hex, :ranch_proxy_protocol, "1.5.0", "e698aaeb590ad504b649dc0d3055abee6caf0b49d3caee1a080ae83b5b499f30", [:rebar3], [{:ranch, "1.5.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "recon": {:hex, :recon, "2.3.2", "4444c879be323b1b133eec5241cb84bd3821ea194c740d75617e106be4744318", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
* Revert otp21 compilation fix changes - we will not be able to release it anyway (can not publish with overridden deps)
* Make examples easier to run

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
