### PR TITLE
Improve connection cleanup on different termination scenarios

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -1,5 +1,6 @@
 {
   "skip_files": [
-    "test"
+    "test",
+    "examples"
   ]
 }

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule GenRMQ.Mixfile do
     ]
   end
 
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["lib", "test/support", "examples"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.


### PR DESCRIPTION
* **Unexpected cancellation (queue deleted or unavailable):**
Connection is closed + consumer terminates with `:cancelled`
reason. This will also emit exit signal to all linked processes,
including supervisor. Unless supervisor restart strategy is `temporary`,
this will trigger consumer restart.

* **Connection closed remotely:**
No need to close connection. Consumer terminates with `:connection_closed`
reason. This will also emit exit signal to all linked processes,
including supervisor. Unless supervisor restart strategy is `temporary`,
this will trigger consumer restart.

* **Consumer stopped gracefully - shutdown reason `normal` or `shutdown`**
Connection is closed. No exit signal.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
