### PR TITLE
Trap exit signals in order to close connection on shutdown

### DIFF
--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -212,6 +212,7 @@ defmodule GenRMQ.Consumer do
   @doc false
   @impl GenServer
   def init(%{module: module} = initial_state) do
+    Process.flag(:trap_exit, true)
     config = apply(module, :init, [])
 
     state =

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -287,9 +287,11 @@ defmodule GenRMQ.Consumer do
 
   @doc false
   @impl GenServer
-  def terminate(reason, %{module: module, conn: conn}) do
+  def terminate(reason, %{module: module, conn: conn, in: in_chan, out: out_chan}) do
     Logger.debug("[#{module}]: Terminating consumer, reason: #{inspect(reason)}")
-    AMQP.Connection.close(conn)
+    Channel.close(in_chan)
+    Channel.close(out_chan)
+    Connection.close(conn)
   end
 
   ##############################################################################

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -144,9 +144,10 @@ defmodule GenRMQ.Publisher do
 
   @doc false
   @impl GenServer
-  def terminate(reason, %{module: module, conn: conn}) do
+  def terminate(reason, %{module: module, conn: conn, channel: channel}) do
     Logger.debug("[#{module}]: Terminating publisher, reason: #{inspect(reason)}")
-    AMQP.Connection.close(conn)
+    Channel.close(channel)
+    Connection.close(conn)
   end
 
   ##############################################################################

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -149,5 +149,18 @@ defmodule GenRMQ.PublisherTest do
       assert "" == meta[:routing_key]
       assert [] == meta[:headers]
     end
+
+    test "should close connection and channel on termination" do
+      Process.flag(:trap_exit, true)
+      {:ok, publisher_pid} = GenRMQ.Publisher.start_link(TestPublisher)
+      state = :sys.get_state(publisher_pid)
+
+      Process.exit(publisher_pid, :shutdown)
+
+      Assert.repeatedly(fn ->
+        assert Process.alive?(state.conn.pid) == false
+        assert Process.alive?(state.channel.pid) == false
+      end)
+    end
   end
 end


### PR DESCRIPTION
This is essential in case of supervisor initiated shutdown,
like whole beam going down. We want to close connection in this
case as well.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
