### PR TITLE
Add error tuple in publish/4 @spec

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -106,7 +106,7 @@ defmodule GenRMQ.Publisher do
           message :: Binary.t(),
           routing_key :: String.t(),
           metadata :: Keyword.t()
-        ) :: :ok
+        ) :: :ok | {:error, reason :: :blocked | :closing}
   def publish(publisher, message, routing_key \\ "", metadata \\ []) do
     GenServer.call(publisher, {:publish, message, routing_key, metadata})
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->
Add error tuple in `publish/4` @spec, publish call `Basic.publish` that can return: [`:ok | {:error, reason :: :blocked | :closing}`](https://github.com/pma/amqp/blob/4cbf3c54b559756c402254b77e39ec6af2058ac4/lib/amqp/basic.ex#L58)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [x] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [x] I have updated the documentation accordingly
