### PR TITLE
Refactor test for consumer with custom deadletter setup

### DIFF
--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -409,12 +409,13 @@ defmodule GenRMQ.Consumer do
         Queue.bind(chan, dl_queue, dl_exchange, routing_key: dl_routing_key)
 
         [{"x-dead-letter-exchange", :longstr, dl_exchange}] ++
-        case dl_routing_key do
-          "#" ->
-            []
-          _ ->
-            [{"x-dead-letter-routing-key", :longstr, dl_routing_key}]
-        end
+          case dl_routing_key do
+            "#" ->
+              []
+
+            _ ->
+              [{"x-dead-letter-routing-key", :longstr, dl_routing_key}]
+          end
 
       false ->
         []

--- a/lib/rabbit_case.ex
+++ b/lib/rabbit_case.ex
@@ -28,8 +28,12 @@ defmodule GenRMQ.RabbitCase do
       end
 
       def get_message_from_queue(context) do
-        {:ok, chan} = AMQP.Channel.open(context[:rabbit_conn])
-        {:ok, payload, meta} = AMQP.Basic.get(chan, context[:out_queue])
+        get_message_from_queue(context[:rabbit_conn], context[:out_queue])
+      end
+
+      def get_message_from_queue(conn, queue) do
+        {:ok, chan} = AMQP.Channel.open(conn)
+        {:ok, payload, meta} = AMQP.Basic.get(chan, queue)
         {:ok, Jason.decode!(payload), meta}
       end
 


### PR DESCRIPTION
* Introduce new test helper to get message from queue - `get_message_from_queue/2`
* Use above test helper in `"TestConsumer.WithCustomDeadletter`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
