### PR TITLE
Give possibility to disable binding creation on consumer startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Optionally, you can:
 * disable deadletter setup by setting `deadletter` attribute to `false`
 * define custom names for deadletter queue / exchange / routing key by specifying `deadletter_queue` / `deadletter_exchange` / `deadletter_routing_key` attributes
 * create a [priority queue][priority_queues] with `queue_max_priority` attribute
+* disable binding creation with `with_binding` attribute
 
 For all available options please check [consumer documentation][consumer_doc].
 

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -71,6 +71,8 @@ defmodule GenRMQ.Consumer do
 
   `deadletter_routing_key` - defines name of the deadletter routing key (**Default:** `#`).
 
+  `with_binding` - gives possibility to setup consumer without binding (**Default:** `true`)
+
   ## Examples:
   ```
   def init() do
@@ -88,7 +90,8 @@ defmodule GenRMQ.Consumer do
       deadletter_queue: "gen_rmq_in_queue_error",
       deadletter_exchange: "gen_rmq_exchange.deadletter",
       deadletter_routing_key: "#",
-      queue_max_priority: 10
+      queue_max_priority: 10,
+      with_binding: true
     ]
   end
   ```
@@ -108,7 +111,8 @@ defmodule GenRMQ.Consumer do
               deadletter_queue: String.t(),
               deadletter_exchange: String.t(),
               deadletter_routing_key: String.t(),
-              queue_max_priority: integer
+              queue_max_priority: integer,
+              with_binding: boolean
             ]
 
   @doc """

--- a/test/gen_rmq_consumer_test.exs
+++ b/test/gen_rmq_consumer_test.exs
@@ -7,6 +7,7 @@ defmodule GenRMQ.ConsumerTest do
   alias GenRMQ.Consumer
   alias TestConsumer.Default
   alias TestConsumer.WithCustomDeadletter
+  alias TestConsumer.WithoutBinding
   alias TestConsumer.WithoutConcurrency
   alias TestConsumer.WithoutDeadletter
   alias TestConsumer.WithoutReconnection
@@ -215,6 +216,20 @@ defmodule GenRMQ.ConsumerTest do
 
       Assert.repeatedly(fn ->
         assert Agent.get(WithPriority, fn set -> message in set end) == true
+      end)
+    end
+  end
+
+  describe "TestConsumer.WithoutBinding" do
+    setup do
+      with_test_consumer(WithoutBinding)
+    end
+
+    test "should create a queue without binding", %{consumer: consumer_pid, state: state} do
+      Assert.repeatedly(fn ->
+        assert Process.alive?(consumer_pid) == true
+        assert is_nil(state[:config][:routing_key])
+        assert is_nil(state[:config][:exchange])
       end)
     end
   end

--- a/test/support/test_consumers.ex
+++ b/test/support/test_consumers.ex
@@ -160,4 +160,27 @@ defmodule TestConsumer do
       GenRMQ.Consumer.ack(message)
     end
   end
+
+  defmodule WithoutBinding do
+    @moduledoc false
+    @behaviour GenRMQ.Consumer
+
+    def init() do
+      [
+        queue: "gen_rmq_in_queue_without_binding",
+        prefetch_count: "10",
+        uri: "amqp://guest:guest@localhost:5672",
+        queue_ttl: 1000,
+        with_binding: false
+      ]
+    end
+
+    def consumer_tag() do
+      "TestConsumer.WithoutBinding"
+    end
+
+    def handle_message(message) do
+      GenRMQ.Consumer.reject(message)
+    end
+  end
 end


### PR DESCRIPTION
Solves https://github.com/meltwater/gen_rmq/issues/92.
TODO:
* Better tests

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
