### PR TITLE
Added more exchange types.

### DIFF
--- a/lib/binding.ex
+++ b/lib/binding.ex
@@ -1,0 +1,70 @@
+defmodule GenRMQ.Binding do
+  @moduledoc """
+  This module defines common methods for
+  declaring consumer bindings and exchanges.
+  """
+
+  @type exchange :: String.t() | {exchange_kind(), String.t()}
+  @type exchange_kind :: :topic | :direct | :fanout
+
+  use AMQP
+
+  @doc false
+  def bind_exchange_and_queue(chan, exchange, queue, routing_key) do
+    declare_exchange(chan, exchange)
+    declare_binding(chan, queue, exchange, routing_key)
+  end
+
+  @doc false
+  def declare_binding(chan, queue, {:fanout, exchange}, _) do
+    bind_queue(chan, queue, exchange, "")
+  end
+
+  def declare_binding(chan, queue, {_, exchange}, routing_key) do
+    bind_queue(chan, queue, exchange, routing_key)
+  end
+
+  def declare_binding(chan, queue, exchange, routing_key) do
+    bind_queue(chan, queue, exchange, routing_key)
+  end
+
+  @doc false
+  def declare_exchange(chan, {:direct, exchange}) do
+    Exchange.direct(chan, exchange, durable: true)
+  end
+
+  def declare_exchange(chan, {:fanout, exchange}) do
+    Exchange.fanout(chan, exchange, durable: true)
+  end
+
+  def declare_exchange(chan, {:topic, exchange}) do
+    Exchange.topic(chan, exchange, durable: true)
+  end
+
+  def declare_exchange(chan, exchange) do
+    Exchange.topic(chan, exchange, durable: true)
+  end
+
+  def exchange_name({_, exchange}) do
+    exchange
+  end
+
+  @doc false
+  def exchange_name(exchange) do
+    exchange
+  end
+
+
+  defp bind_queue(chan, queue, exchange_name, routing_key) when is_list(routing_key) do
+    Enum.reduce_while(routing_key, :ok, fn(rk, acc) ->
+      case Queue.bind(chan, queue, exchange_name, routing_key: rk) do
+        :ok -> {:cont, acc}
+        err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp bind_queue(chan, queue, exchange_name, routing_key) do
+    Queue.bind(chan, queue, exchange_name, routing_key: routing_key)
+  end
+end

--- a/lib/rabbit_case.ex
+++ b/lib/rabbit_case.ex
@@ -14,8 +14,8 @@ defmodule GenRMQ.RabbitCase do
 
       def publish_message(conn, exchange, message, routing_key \\ "#", meta \\ []) do
         {:ok, channel} = AMQP.Channel.open(conn)
-        AMQP.Exchange.topic(channel, exchange, durable: true)
-        AMQP.Basic.publish(channel, exchange, routing_key, message, meta)
+        GenRMQ.Binding.declare_exchange(channel, exchange)
+        AMQP.Basic.publish(channel, GenRMQ.Binding.exchange_name(exchange), routing_key, message, meta)
         AMQP.Channel.close(channel)
       end
 

--- a/test/support/consumer_shared_tests.ex
+++ b/test/support/consumer_shared_tests.ex
@@ -1,0 +1,98 @@
+defmodule ConsumerSharedTests do
+  @moduledoc """
+  Shared tests used by multiple consumers.
+  """
+
+  defmacro receive_message_test(mod) do
+    quote do
+      test "should receive a message", context do
+        message = %{"msg" => "some message"}
+
+        publish_message(context[:rabbit_conn], context[:exchange], Jason.encode!(message))
+
+        GenRMQ.Test.Assert.repeatedly(fn ->
+          assert Agent.get(unquote(mod), fn set -> message in set end) == true
+        end)
+      end
+    end
+  end
+
+  defmacro reject_message_test do
+    quote do
+      test "should reject a message", %{state: state} = context do
+        message = "reject"
+
+        publish_message(context[:rabbit_conn], context[:exchange], Jason.encode!(message))
+
+        GenRMQ.Test.Assert.repeatedly(fn ->
+          assert queue_count(context[:rabbit_conn], "#{state.config[:queue]}_error") == {:ok, 1}
+        end)
+      end
+    end
+  end
+
+  defmacro reconnect_after_connection_failure_test(mod) do
+    quote do
+      test "should reconnect after connection failure", %{state: state} = context do
+        message = "disconnect"
+        AMQP.Connection.close(state.conn)
+
+        publish_message(context[:rabbit_conn], context[:exchange], Jason.encode!(message))
+
+        GenRMQ.Test.Assert.repeatedly(fn ->
+          assert Agent.get(unquote(mod), fn set -> message in set end) == true
+        end)
+      end
+    end
+  end
+
+  defmacro terminate_after_queue_deletion_test do
+    quote do
+      test "should terminate after queue deletion", %{consumer: consumer_pid, state: state} do
+        AMQP.Queue.delete(state.out, state[:config][:queue])
+
+        GenRMQ.Test.Assert.repeatedly(fn ->
+          assert Process.alive?(consumer_pid) == false
+        end)
+      end
+    end
+  end
+
+  defmacro exit_signal_after_queue_deletion_test do
+    quote do
+      test "should send exit signal after queue deletion", %{consumer: consumer_pid, state: state} do
+        AMQP.Queue.delete(state.out, state[:config][:queue])
+
+        assert_receive({:EXIT, ^consumer_pid, :cancelled})
+      end
+    end
+  end
+
+  defmacro close_connection_and_channels_after_deletion_test do
+    quote do
+      test "should close connection and channels after queue deletion", %{state: state} do
+        AMQP.Queue.delete(state.out, state[:config][:queue])
+
+        GenRMQ.Test.Assert.repeatedly(fn ->
+          assert Process.alive?(state.conn.pid) == false
+          assert Process.alive?(state.in.pid) == false
+          assert Process.alive?(state.out.pid) == false
+        end)
+      end
+    end
+  end
+
+  defmacro close_connection_and_channels_after_shutdown_test do
+    quote do
+      test "should close connection and channels after shutdown signal", %{consumer: consumer_pid, state: state} do
+        Process.exit(consumer_pid, :shutdown)
+
+        GenRMQ.Test.Assert.repeatedly(fn ->
+          assert Process.alive?(state.conn.pid) == false
+          assert Process.alive?(state.in.pid) == false
+          assert Process.alive?(state.out.pid) == false
+        end)
+      end
+    end
+  end
+end

--- a/test/support/test_consumers.ex
+++ b/test/support/test_consumers.ex
@@ -160,4 +160,124 @@ defmodule TestConsumer do
       GenRMQ.Consumer.ack(message)
     end
   end
+
+  defmodule WithTopicExchange do
+    @moduledoc false
+    @behaviour GenRMQ.Consumer
+
+    def init() do
+      [
+        queue: "gen_rmq_wt_in_queue",
+        exchange: {:topic, "gen_rmq_in_wt_exchange"},
+        routing_key: "#",
+        prefetch_count: "10",
+        uri: "amqp://guest:guest@localhost:5672",
+        queue_ttl: 1000
+      ]
+    end
+
+    def consumer_tag() do
+      "TestConsumer.WithTopicExchange"
+    end
+
+    def handle_message(%GenRMQ.Message{payload: "\"reject\""} = message) do
+      GenRMQ.Consumer.reject(message)
+    end
+
+    def handle_message(message) do
+      payload = Jason.decode!(message.payload)
+      Agent.update(__MODULE__, &MapSet.put(&1, payload))
+      GenRMQ.Consumer.ack(message)
+    end
+  end
+
+  defmodule WithDirectExchange do
+    @moduledoc false
+    @behaviour GenRMQ.Consumer
+
+    def init() do
+      [
+        queue: "gen_rmq_wd_in_queue",
+        exchange: {:direct, "gen_rmq_in_wd_exchange"},
+        routing_key: "#",
+        prefetch_count: "10",
+        uri: "amqp://guest:guest@localhost:5672",
+        queue_ttl: 1000
+      ]
+    end
+
+    def consumer_tag() do
+      "TestConsumer.WithDirectExchange"
+    end
+
+    def handle_message(%GenRMQ.Message{payload: "\"reject\""} = message) do
+      GenRMQ.Consumer.reject(message)
+    end
+
+    def handle_message(message) do
+      payload = Jason.decode!(message.payload)
+      Agent.update(__MODULE__, &MapSet.put(&1, payload))
+      GenRMQ.Consumer.ack(message)
+    end
+  end
+
+  defmodule WithFanoutExchange do
+    @moduledoc false
+    @behaviour GenRMQ.Consumer
+
+    def init() do
+      [
+        queue: "gen_rmq_wf_in_queue",
+        exchange: {:fanout, "gen_rmq_in_wf_exchange"},
+        routing_key: "#",
+        prefetch_count: "10",
+        uri: "amqp://guest:guest@localhost:5672",
+        queue_ttl: 1000
+      ]
+    end
+
+    def consumer_tag() do
+      "TestConsumer.WithDirectExchange"
+    end
+
+    def handle_message(%GenRMQ.Message{payload: "\"reject\""} = message) do
+      GenRMQ.Consumer.reject(message)
+    end
+
+    def handle_message(message) do
+      payload = Jason.decode!(message.payload)
+      Agent.update(__MODULE__, &MapSet.put(&1, payload))
+      GenRMQ.Consumer.ack(message)
+    end
+  end
+
+  defmodule WithMultiBindingExchange do
+    @moduledoc false
+    @behaviour GenRMQ.Consumer
+
+    def init() do
+      [
+        queue: "gen_rmq_mb_in_queue",
+        exchange: {:direct, "gen_rmq_in_mb_exchange"},
+        routing_key: ["routing_key_1", "routing_key_2"],
+        prefetch_count: "10",
+        uri: "amqp://guest:guest@localhost:5672",
+        queue_ttl: 1000
+      ]
+    end
+
+    def consumer_tag() do
+      "TestConsumer.WithMultiBindingExchange"
+    end
+
+    def handle_message(%GenRMQ.Message{payload: "\"reject\""} = message) do
+      GenRMQ.Consumer.reject(message)
+    end
+
+    def handle_message(message) do
+      payload = Jason.decode!(message.payload)
+      Agent.update(__MODULE__, &MapSet.put(&1, payload))
+      GenRMQ.Consumer.ack(message)
+    end
+  end
 end


### PR DESCRIPTION
Add more exchange types, with the exception of the headers exchange.

Creating a headers exchange would require more complex logic for the
routing key than a string or list of strings.

I will open another issue specifically for headers based exchanges and
routing keys.

Fixes #93.