### PR TITLE
Support publisher confirmations

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -114,7 +114,7 @@ defmodule GenRMQ.Publisher do
           message :: String.t(),
           routing_key :: String.t(),
           metadata :: Keyword.t()
-        ) :: :ok | {:error, reason :: :blocked | :closing | :timeout}
+        ) :: :ok | {:error, reason :: :blocked | :closing | :confirmation_timeout}
   def publish(publisher, message, routing_key \\ "", metadata \\ []) do
     GenServer.call(publisher, {:publish, message, routing_key, metadata})
   end
@@ -193,7 +193,7 @@ defmodule GenRMQ.Publisher do
   defp wait_for_confirmation(_, _, _), do: true
 
   defp publish_result(:ok, true), do: :ok
-  defp publish_result(:ok, :timeout), do: {:error, :confirmat_timeout}
+  defp publish_result(:ok, :timeout), do: {:error, :confirmation_timeout}
   defp publish_result(error, _), do: error
 
   defp connect(%{module: module, config: config} = state) do

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -32,7 +32,7 @@ defmodule GenRMQ.Publisher do
 
   `app_id` - publishing application ID
 
-  `activate_confirmations` - activates publishing confirmations on the channel
+  `enable_confirmations` - activates publishing confirmations on the channel. By default it is `false`.
 
   `max_confirmation_wait_time` - maximum time in milliseconds to wait for a confirmation. By default it is 5_000 (5s).
 
@@ -43,7 +43,7 @@ defmodule GenRMQ.Publisher do
       exchange: "gen_rmq_exchange",
       uri: "amqp://guest:guest@localhost:5672"
       app_id: :my_app_id,
-      activate_confirmations: true,
+      enable_confirmations: true,
       max_confirmation_wait_time: 5_000
     ]
   end
@@ -54,7 +54,7 @@ defmodule GenRMQ.Publisher do
               exchange: GenRMQ.Binding.exchange(),
               uri: String.t(),
               app_id: atom,
-              activate_confirmations: boolean,
+              enable_confirmations: boolean,
               max_confirmation_wait_time: integer
             ]
 
@@ -175,7 +175,7 @@ defmodule GenRMQ.Publisher do
     {:ok, channel} = Channel.open(conn)
     GenRMQ.Binding.declare_exchange(channel, config[:exchange])
 
-    with_confirmations = Keyword.get(config, :activate_confirmations, false)
+    with_confirmations = Keyword.get(config, :enable_confirmations, false)
     :ok = activate_confirmations(channel, with_confirmations)
     {:ok, %{channel: channel, module: module, config: config, conn: conn}}
   end
@@ -184,7 +184,7 @@ defmodule GenRMQ.Publisher do
   defp activate_confirmations(_, _), do: :ok
 
   defp wait_for_confirmation(channel, config) do
-    with_confirmations = Keyword.get(config, :activate_confirmations, false)
+    with_confirmations = Keyword.get(config, :enable_confirmations, false)
     max_wait_time = config |> Keyword.get(:max_confirmation_wait_time, 5_000)
     wait_for_confirmation(channel, with_confirmations, max_wait_time)
   end

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -34,7 +34,7 @@ defmodule GenRMQ.Publisher do
 
   `activate_confirmations` - activates publishing confirmations on the channel
 
-  `max_confirmation_wait_time` - maximum time in seconds to wait for a confirmation
+  `max_confirmation_wait_time` - maximum time in milliseconds to wait for a confirmation. By default it is 5_000 (5s).
 
   ## Examples:
   ```
@@ -44,7 +44,7 @@ defmodule GenRMQ.Publisher do
       uri: "amqp://guest:guest@localhost:5672"
       app_id: :my_app_id,
       activate_confirmations: true,
-      max_confirmation_wait_time: 10
+      max_confirmation_wait_time: 5_000
     ]
   end
   ```
@@ -185,7 +185,7 @@ defmodule GenRMQ.Publisher do
 
   defp wait_for_confirmation(channel, config) do
     with_confirmations = Keyword.get(config, :activate_confirmations, false)
-    max_wait_time = config |> Keyword.get(:max_confirmation_wait_time, 10) |> :timer.seconds()
+    max_wait_time = config |> Keyword.get(:max_confirmation_wait_time, 5_000)
     wait_for_confirmation(channel, with_confirmations, max_wait_time)
   end
 

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -180,8 +180,8 @@ defmodule GenRMQ.Publisher do
     {:ok, %{channel: channel, module: module, config: config, conn: conn}}
   end
 
+  defp activate_confirmations(_, false), do: :ok
   defp activate_confirmations(channel, true), do: AMQP.Confirm.select(channel)
-  defp activate_confirmations(_, _), do: :ok
 
   defp wait_for_confirmation(channel, config) do
     with_confirmations = Keyword.get(config, :enable_confirmations, false)
@@ -189,8 +189,8 @@ defmodule GenRMQ.Publisher do
     wait_for_confirmation(channel, with_confirmations, max_wait_time)
   end
 
+  defp wait_for_confirmation(_, false, _), do: true
   defp wait_for_confirmation(channel, true, max_wait_time), do: AMQP.Confirm.wait_for_confirms(channel, max_wait_time)
-  defp wait_for_confirmation(_, _, _), do: true
 
   defp publish_result(:ok, true), do: :ok
   defp publish_result(:ok, :timeout), do: {:error, :confirmation_timeout}

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -26,13 +26,14 @@ defmodule GenRMQ.Publisher do
 
   `uri` - RabbitMQ uri
 
-  `exchange` - the target exchange. If does not exist, it will be created.
+  `exchange` - name or `{type, name}` of the target exchange. If it does not exist, it will be created.
+  For valid exchange types see `GenRMQ.Binding`.
 
   ### Optional:
 
   `app_id` - publishing application ID
 
-  `enable_confirmations` - activates publishing confirmations on the channel. By default it is `false`.
+  `enable_confirmations` - activates publishing confirmations on the channel. Confirmations are disabled by default.
 
   `max_confirmation_wait_time` - maximum time in milliseconds to wait for a confirmation. By default it is 5_000 (5s).
 

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -7,7 +7,6 @@ defmodule GenRMQ.PublisherTest do
 
   alias TestPublisher.Default
   alias TestPublisher.WithConfirmations
-  alias TestPublisher.WithConfirmationsAnd0Timeout
 
   @uri "amqp://guest:guest@localhost:5672"
   @exchange "gen_rmq_out_exchange"
@@ -160,19 +159,6 @@ defmodule GenRMQ.PublisherTest do
       Assert.repeatedly(fn -> assert out_queue_count(context) >= 1 end)
       assert match?({:ok, ^message, _}, get_message_from_queue(context))
       assert {:ok, :confirmed} == publish_result
-    end
-  end
-
-  describe "TestPublisher.WithConfirmationsAnd0Timeout" do
-    setup do
-      with_test_publisher(WithConfirmationsAnd0Timeout)
-    end
-
-    test "should return timeout error while waiting for a confirmation", %{publisher: publisher_pid} do
-      message = %{"msg" => "with confirmation"}
-      result = GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(message), "some.routing.key")
-
-      assert {:error, :confirmation_timeout} == result
     end
   end
 

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -7,6 +7,7 @@ defmodule GenRMQ.PublisherTest do
 
   alias TestPublisher.Default
   alias TestPublisher.WithConfirmations
+  alias TestPublisher.WithConfirmationsAnd0Timeout
 
   @uri "amqp://guest:guest@localhost:5672"
   @exchange "gen_rmq_out_exchange"
@@ -160,6 +161,19 @@ defmodule GenRMQ.PublisherTest do
       {:ok, received_message, _meta} = get_message_from_queue(context)
 
       assert message == received_message
+    end
+  end
+
+  describe "TestPublisher.WithConfirmationsAnd0Timeout" do
+    setup do
+      with_test_publisher(WithConfirmationsAnd0Timeout)
+    end
+
+    test "should return timeout error while waiting for a confirmation", %{publisher: publisher_pid} do
+      message = %{"msg" => "with confirmation"}
+      result = GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(message), "some.routing.key")
+
+      assert {:error, :confirmat_timeout} == result
     end
   end
 

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -173,7 +173,7 @@ defmodule GenRMQ.PublisherTest do
       message = %{"msg" => "with confirmation"}
       result = GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(message), "some.routing.key")
 
-      assert {:error, :confirmat_timeout} == result
+      assert {:error, :confirmation_timeout} == result
     end
   end
 

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -155,12 +155,11 @@ defmodule GenRMQ.PublisherTest do
 
     test "should publish a message and wait for a confirmation", %{publisher: publisher_pid} = context do
       message = %{"msg" => "with confirmation"}
-      GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(message), "some.routing.key")
+      publish_result = GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(message), "some.routing.key")
 
       Assert.repeatedly(fn -> assert out_queue_count(context) >= 1 end)
-      {:ok, received_message, _meta} = get_message_from_queue(context)
-
-      assert message == received_message
+      assert match?({:ok, ^message, _}, get_message_from_queue(context))
+      assert {:ok, :confirmed} == publish_result
     end
   end
 

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -42,7 +42,7 @@ defmodule GenRMQ.PublisherTest do
     test "should publish message", %{publisher: publisher_pid} = context do
       message = %{"msg" => "msg"}
 
-      GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(%{"msg" => "msg"}))
+      :ok = GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(%{"msg" => "msg"}))
 
       Assert.repeatedly(fn -> assert out_queue_count(context) >= 1 end)
       {:ok, received_message, meta} = get_message_from_queue(context)
@@ -68,7 +68,7 @@ defmodule GenRMQ.PublisherTest do
     test "should publish message with headers", %{publisher: publisher_pid} = context do
       message = %{"msg" => "msg"}
 
-      GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(message), "some.routing.key", header1: "value")
+      :ok = GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(message), "some.routing.key", header1: "value")
 
       Assert.repeatedly(fn -> assert out_queue_count(context) >= 1 end)
       {:ok, received_message, meta} = get_message_from_queue(context)
@@ -80,7 +80,7 @@ defmodule GenRMQ.PublisherTest do
     test "should override standard metadata fields from headers", %{publisher: publisher_pid} = context do
       message = %{"msg" => "msg"}
 
-      GenRMQ.Publisher.publish(
+      :ok = GenRMQ.Publisher.publish(
         publisher_pid,
         Jason.encode!(message),
         "some.routing.key",
@@ -103,7 +103,7 @@ defmodule GenRMQ.PublisherTest do
     test "should publish a message with priority", %{publisher: publisher_pid} = context do
       message = %{"msg" => "with prio"}
 
-      GenRMQ.Publisher.publish(
+      :ok = GenRMQ.Publisher.publish(
         publisher_pid,
         Jason.encode!(message),
         "some.routing.key",
@@ -127,7 +127,7 @@ defmodule GenRMQ.PublisherTest do
         assert new_state.channel.conn.pid != state.channel.conn.pid
       end)
 
-      GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(message))
+      :ok = GenRMQ.Publisher.publish(publisher_pid, Jason.encode!(message))
 
       Assert.repeatedly(fn -> assert out_queue_count(context) >= 1 end)
       {:ok, received_message, meta} = get_message_from_queue(context)

--- a/test/support/test_publishers.ex
+++ b/test/support/test_publishers.ex
@@ -1,0 +1,28 @@
+defmodule TestPublisher do
+  defmodule Default do
+    @moduledoc false
+    @behaviour GenRMQ.Publisher
+
+    def init() do
+      [
+        exchange: "gen_rmq_out_exchange",
+        uri: "amqp://guest:guest@localhost:5672",
+        app_id: :my_app_id
+      ]
+    end
+  end
+
+  defmodule WithConfirmations do
+    @moduledoc false
+    @behaviour GenRMQ.Publisher
+
+    def init() do
+      [
+        exchange: "gen_rmq_out_exchange",
+        uri: "amqp://guest:guest@localhost:5672",
+        app_id: :my_app_id,
+        activate_confirmations: true
+      ]
+    end
+  end
+end

--- a/test/support/test_publishers.ex
+++ b/test/support/test_publishers.ex
@@ -25,19 +25,4 @@ defmodule TestPublisher do
       ]
     end
   end
-
-  defmodule WithConfirmationsAnd0Timeout do
-    @moduledoc false
-    @behaviour GenRMQ.Publisher
-
-    def init() do
-      [
-        exchange: "gen_rmq_out_exchange",
-        uri: "amqp://guest:guest@localhost:5672",
-        app_id: :my_app_id,
-        enable_confirmations: true,
-        max_confirmation_wait_time: 0
-      ]
-    end
-  end
 end

--- a/test/support/test_publishers.ex
+++ b/test/support/test_publishers.ex
@@ -25,4 +25,19 @@ defmodule TestPublisher do
       ]
     end
   end
+
+  defmodule WithConfirmationsAnd0Timeout do
+    @moduledoc false
+    @behaviour GenRMQ.Publisher
+
+    def init() do
+      [
+        exchange: "gen_rmq_out_exchange",
+        uri: "amqp://guest:guest@localhost:5672",
+        app_id: :my_app_id,
+        activate_confirmations: true,
+        max_confirmation_wait_time: 0
+      ]
+    end
+  end
 end

--- a/test/support/test_publishers.ex
+++ b/test/support/test_publishers.ex
@@ -21,7 +21,7 @@ defmodule TestPublisher do
         exchange: "gen_rmq_out_exchange",
         uri: "amqp://guest:guest@localhost:5672",
         app_id: :my_app_id,
-        activate_confirmations: true
+        enable_confirmations: true
       ]
     end
   end

--- a/test/support/test_publishers.ex
+++ b/test/support/test_publishers.ex
@@ -35,7 +35,7 @@ defmodule TestPublisher do
         exchange: "gen_rmq_out_exchange",
         uri: "amqp://guest:guest@localhost:5672",
         app_id: :my_app_id,
-        activate_confirmations: true,
+        enable_confirmations: true,
         max_confirmation_wait_time: 0
       ]
     end


### PR DESCRIPTION
[Publisher confirmations](https://www.rabbitmq.com/confirms.html#publisher-confirms), is a mechanism to ensure that a published message actually reached a broker.

**How:**
Extend publisher configuration with two optional attributes:
* `enable_confirmations` - when set to `true`, confirmations will be activated on the channel during publisher setup + confirmation will be awaited on every publish
* `max_confirmation_wait_time` - maximum time in milliseconds, that publisher will wait for a confirmation from a broker before timeouting

**Other:**
* Move test publishers to a separate module 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
