### PR TITLE
Remove code using Mix module from Publisher

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -5,7 +5,6 @@ defmodule GenRMQ.Publisher do
 
   use GenServer
   use AMQP
-  alias Mix.Project
 
   require Logger
 
@@ -231,7 +230,7 @@ defmodule GenRMQ.Publisher do
   end
 
   defp app_id(config) do
-    config[:app_id] || Keyword.get(Project.config(), :app)
+    config[:app_id]
   end
 
   ##############################################################################

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -230,7 +230,7 @@ defmodule GenRMQ.Publisher do
   end
 
   defp app_id(config) do
-    config[:app_id]
+    config[:app_id] || :gen_rmq
   end
 
   ##############################################################################


### PR DESCRIPTION
Elixir 1.9 can package projects as releases (similar to Distillery). Releases do not include the Mix module.

A project using GenRMQ could not be run as a release because the GenRMQ Publisher uses Mix to lookup a default app_id. I've fixed this rather crudely by removing the code using Mix, tests still pass but it may be a breaking change for some apps.

It should be possible to conditionally compile the module with or without the Mix code depending on whether or not it is being compiled for release but I thought this would be confusing to end-users.
