### PR TITLE
Fixes #118 and formats docs correctly

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -133,19 +133,6 @@ defmodule GenRMQ.Publisher do
     GenServer.call(publisher, {:publish, message, routing_key, metadata})
   end
 
-  @doc """
-  Gets the channel handlerassociate with the given publisher. Be aware that the channel
-  may be invalidated after this function returns so it is suggested that this channel
-  handler not be used long after this function call or persisted anywhere else. Its
-  primary use is as an escape hatch from gen_rmq to call arbitrary amqp functions.
-
-  `publisher` - name or PID of the publisher
-  """
-  @spec get_channel(publisher :: atom | pid) :: :integer
-  def get_channel(publisher) do
-    GenServer.call(publisher, :get_channel)
-  end
-
   ##############################################################################
   # GenServer callbacks
   ##############################################################################
@@ -167,12 +154,6 @@ defmodule GenRMQ.Publisher do
     publish_result = Basic.publish(channel, GenRMQ.Binding.exchange_name(config[:exchange]), key, msg, metadata)
     confirmation_result = wait_for_confirmation(channel, config)
     {:reply, publish_result(publish_result, confirmation_result), state}
-  end
-
-  @doc false
-  @impl GenServer
-  def handle_call(:get_channel, _from, %{channel: channel} = state) do
-    {:reply, channel, state}
   end
 
   @doc false

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -9,9 +9,23 @@ defmodule GenRMQ.Publisher do
   require Logger
 
   # list of fields permitted in message metadata at top level
-  @metadata_fields :P_basic
-                   |> Record.extract(from_lib: "rabbit_common/include/rabbit_framing.hrl")
-                   |> Keyword.keys()
+  @metadata_fields ~w(
+    mandatory
+    immediate
+    content_type
+    content_encoding
+    persistent
+    priority
+    correlation_id
+    reply_to
+    expiration
+    message_id
+    timestamp
+    type
+    user_id
+    app_id
+    cluster_id
+  )a
 
   ##############################################################################
   # GenRMQ.Publisher callbacks
@@ -97,11 +111,11 @@ defmodule GenRMQ.Publisher do
 
   `routing_key` - optional routing key to set for given message
 
-  `metadata` - optional metadata to set for given message. Keys that
-              are not allowed in metadata are moved under the `:headers`
-              field. Do not include a `:headers` field here: it will be
-              created automatically with all non-standard keys that you have
-              provided.
+  `metadata` - optional metadata to set for given message. Keys that \
+              are not allowed in metadata are moved under the `:headers` \
+              field. Do not include a `:headers` field here: it will be \
+              created automatically with all non-standard keys that you have \
+              provided. For a full list of options see `AMQP.Basic.publish/5`
 
   ## Examples:
   ```

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -141,7 +141,7 @@ defmodule GenRMQ.Publisher do
 
   `publisher` - name or PID of the publisher
   """
-  @spec get_channel(publisher :: atom | pid)
+  @spec get_channel(publisher :: atom | pid) :: :integer
   def get_channel(publisher) do
     GenServer.call(publisher, :get_channel)
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This change allows gen_rmq to allow for persisted messages by passing the proper options to the amqp library (fixes #118). You can now pass any valid amqp library option and it works as expected like so: `GenRMQ.Publisher.publish(__MODULE__, payload, "my_queue", [persistent: true])`.

## Checklist
- [ ] I have added unit tests to cover my changes.
- [X] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [X] I have updated the documentation accordingly
