### PR TITLE
Expose channel from gen_rmq producers

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -134,10 +134,10 @@ defmodule GenRMQ.Publisher do
   end
 
   @doc """
-  Gets the channel handlerassociate with the given publisher. Be aware that the channel
+  Gets the channel handler associated with the given publisher. Be aware that the channel
   may be invalidated after this function returns so it is suggested that this channel
   handler not be used long after this function call or persisted anywhere else. Its
-  primary use is as an escape hatch from gen_rmq to call arbitrary amqp functions.
+  primary use is as an escape hatch from gen_rmq to call arbitrary AMQP functions.
 
   `publisher` - name or PID of the publisher
   """

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -9,9 +9,23 @@ defmodule GenRMQ.Publisher do
   require Logger
 
   # list of fields permitted in message metadata at top level
-  @metadata_fields :P_basic
-                   |> Record.extract(from_lib: "rabbit_common/include/rabbit_framing.hrl")
-                   |> Keyword.keys()
+  @metadata_fields ~w(
+    mandatory
+    immediate
+    content_type
+    content_encoding
+    persistent
+    priority
+    correlation_id
+    reply_to
+    expiration
+    message_id
+    timestamp
+    type
+    user_id
+    app_id
+    cluster_id
+  )a
 
   ##############################################################################
   # GenRMQ.Publisher callbacks
@@ -97,11 +111,11 @@ defmodule GenRMQ.Publisher do
 
   `routing_key` - optional routing key to set for given message
 
-  `metadata` - optional metadata to set for given message. Keys that
-              are not allowed in metadata are moved under the `:headers`
-              field. Do not include a `:headers` field here: it will be
-              created automatically with all non-standard keys that you have
-              provided.
+  `metadata` - optional metadata to set for given message. Keys that \
+              are not allowed in metadata are moved under the `:headers` \
+              field. Do not include a `:headers` field here: it will be \
+              created automatically with all non-standard keys that you have \
+              provided. For a full list of options see `AMQP.Basic.publish/5`
 
   ## Examples:
   ```

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -141,7 +141,7 @@ defmodule GenRMQ.Publisher do
 
   `publisher` - name or PID of the publisher
   """
-  @spec get_channel(publisher :: atom | pid)
+  @spec get_channel(publisher :: atom | pid) :: :integer
   def get_channel(publisher) do
     GenServer.call(publisher, :get_channel)
   end


### PR DESCRIPTION
## Description
The purpose of this change is to have access to the underlying channel associated with the gen_rmq process. This is useful (at least for me) when performing operations via AMQP that are not directly supported via gen_rmq. It is also convenient not to have to open and close additional channels when ancillary work needs to be performed. For example, it may be useful for a message producer to be aware of the queue size (via `AMQP.Queue.message_count/2`) as not to flood the queue and throttle itself.

A simple example of its usage would be like so from within a RMQPublisher module:
```elixir
def queue_size do                          
  __MODULE__                                     
  |> GenRMQ.Publisher.get_channel()              
  |> AMQP.Queue.message_count(@queue_name)
end                                              
```

## Checklist
- [X] I have added unit tests to cover my changes.
- [X] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [X] I have updated the documentation accordingly
