### PR TITLE
Added Publisher.get_channel/1 to expose channel and tests

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -133,6 +133,18 @@ defmodule GenRMQ.Publisher do
     GenServer.call(publisher, {:publish, message, routing_key, metadata})
   end
 
+  @doc """
+  Gets the channel handler associated with the given publisher. Be aware that the channel
+  may be invalidated after this function returns so it is suggested that this channel
+  handler not be used long after this function call or persisted anywhere else. Its
+  primary use is as an escape hatch from gen_rmq to call arbitrary AMQP functions.
+  `publisher` - name or PID of the publisher
+  """
+  @spec get_channel(publisher :: atom | pid) :: :integer
+  def get_channel(publisher) do
+    GenServer.call(publisher, :get_channel)
+  end
+
   ##############################################################################
   # GenServer callbacks
   ##############################################################################
@@ -154,6 +166,12 @@ defmodule GenRMQ.Publisher do
     publish_result = Basic.publish(channel, GenRMQ.Binding.exchange_name(config[:exchange]), key, msg, metadata)
     confirmation_result = wait_for_confirmation(channel, config)
     {:reply, publish_result(publish_result, confirmation_result), state}
+  end
+
+  @doc false
+  @impl GenServer
+  def handle_call(:get_channel, _from, %{channel: channel} = state) do
+    {:reply, channel, state}
   end
 
   @doc false


### PR DESCRIPTION
## Description
The purpose of this change is to have access to the underlying channel associated with the gen_rmq process. This is useful (at least for me) when performing operations via AMQP that are not directly supported via gen_rmq. It is also convenient not to have to open and close additional channels when ancillary work needs to be performed. For example, it may be useful for a message producer to be aware of the queue size (via `AMQP.Queue.message_count/2`) as not to flood the queue and throttle itself.

A simple example of its usage would be like so from within a RMQPublisher module:
```elixir
def queue_size do                          
  __MODULE__                                     
  |> GenRMQ.Publisher.get_channel()              
  |> AMQP.Queue.message_count(@queue_name)
end                                              
```

## Checklist
- [X] I have added unit tests to cover my changes.
- [X] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [X] I have updated the documentation accordingly