### PR TITLE
Give possibility to override all metadata fields

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -334,10 +334,10 @@ defmodule GenRMQ.Publisher do
   # Put standard metadata fields to top level, everything else into headers
   defp merge_metadata(base, custom) do
     {metadata, headers} = custom |> Keyword.split(@metadata_fields)
-    # take "standard" fields and put them into metadata top-level
-    metadata
-    # put default values, override custom values on conflict
-    |> Keyword.merge(base)
+    # take "base" fields and put them into metadata top-level
+    base
+    # put custom values, override base values on conflict
+    |> Keyword.merge(metadata)
     # put all custom fields in the headers
     |> Keyword.merge(headers: headers)
   end


### PR DESCRIPTION
Including `app_id`, `content_type` and `timestamp`. At the moment these values can not be modified by the user.

**Implementation details:**
Just reverse metadata merging, so custom values can override default ones.

Fixes https://github.com/meltwater/gen_rmq/issues/128

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
