### PR TITLE
Refactor consumer settings.

### DIFF
--- a/lib/gen_rmq/consumer/queue_configuration.ex
+++ b/lib/gen_rmq/consumer/queue_configuration.ex
@@ -1,0 +1,90 @@
+defmodule GenRMQ.Consumer.QueueConfiguration do
+  @moduledoc false
+
+  defstruct name: nil,
+            ttl: nil,
+            max_priority: nil,
+            durable: true
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          ttl: nil | pos_integer,
+          max_priority: nil | pos_integer,
+          durable: boolean
+        }
+
+  @type queue_options ::
+          []
+          | [durable: boolean]
+          | [durable: boolean, max_priority: pos_integer]
+          | [durable: boolean, ttl: pos_integer]
+          | [max_priority: pos_integer]
+          | [max_priority: pos_integer, ttl: pos_integer]
+          | [durable: boolean, max_priority: pos_integer, ttl: pos_integer]
+
+  @spec new(String.t(), queue_options) :: t
+  def new(name, args \\ []) do
+    queue_ttl = Keyword.get(args, :ttl, nil)
+    queue_mp = Keyword.get(args, :max_priority, nil)
+    durable = Keyword.get(args, :durable, true)
+
+    %__MODULE__{
+      name: name,
+      ttl: queue_ttl,
+      max_priority: set_max_priority_to_highest_value(queue_mp),
+      durable: durable
+    }
+  end
+
+  @spec new(String.t(), boolean, nil | pos_integer, nil | pos_integer) :: t
+  def new(name, durable, ttl, mp) do
+    %__MODULE__{
+      name: name,
+      ttl: ttl,
+      max_priority: set_max_priority_to_highest_value(mp),
+      durable: durable
+    }
+  end
+
+  @spec name(t) :: String.t()
+  def name(%__MODULE__{name: n}), do: n
+
+  @spec durable(t) :: boolean
+  def durable(%__MODULE__{durable: d}), do: d
+
+  @spec ttl(t) :: nil | pos_integer
+  def ttl(%__MODULE__{ttl: ttl_v}), do: ttl_v
+
+  @spec max_priority(t) :: nil | pos_integer
+  def max_priority(%__MODULE__{max_priority: mp}), do: mp
+
+  def build_queue_arguments(%__MODULE__{} = qc, arguments) do
+    args_with_priority = setup_priority(arguments, qc.max_priority)
+
+    qc
+    |> build_ttl_arguments(args_with_priority)
+  end
+
+  def build_ttl_arguments(%__MODULE__{} = qc, arguments) do
+    setup_ttl(arguments, qc.ttl)
+  end
+
+  defp setup_ttl(arguments, nil), do: arguments
+  defp setup_ttl(arguments, ttl), do: [{"x-expires", :long, ttl} | arguments]
+
+  defp setup_priority(arguments, max_priority) when is_integer(max_priority),
+    do: [{"x-max-priority", :long, max_priority} | arguments]
+
+  defp setup_priority(arguments, _), do: arguments
+
+  @max_priority 255
+
+  defp set_max_priority_to_highest_value(nil), do: nil
+
+  defp set_max_priority_to_highest_value(mp)
+       when is_integer(mp) and mp > @max_priority do
+    255
+  end
+
+  defp set_max_priority_to_highest_value(mp) when is_integer(mp), do: mp
+end

--- a/lib/gen_rmq/consumer/queue_configuration.ex
+++ b/lib/gen_rmq/consumer/queue_configuration.ex
@@ -1,5 +1,11 @@
 defmodule GenRMQ.Consumer.QueueConfiguration do
-  @moduledoc false
+  @moduledoc """
+  Represents configuration of a Consumer queue.
+
+  While this module exists to make management of Consumer queue configurations
+  easier, right now it should be considered a private implementation detail
+  with respect to the consumer configuration API.
+  """
 
   defstruct name: nil,
             ttl: nil,

--- a/test/gen_rmq/consumer/queue_configuration_test.exs
+++ b/test/gen_rmq/consumer/queue_configuration_test.exs
@@ -4,12 +4,12 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
 
   test "may be built with just a queue name" do
     qc = QueueConfiguration.new("some_queue_name")
-    "some_queue_name" = QueueConfiguration.name(qc)
+    assert "some_queue_name" == QueueConfiguration.name(qc)
   end
 
   test "durable should default to true" do
     qc = QueueConfiguration.new("some_queue_name")
-    true = QueueConfiguration.durable(qc)
+    assert QueueConfiguration.durable(qc)
   end
 
   test "may be built with all options" do
@@ -26,21 +26,20 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         max_priority
       )
 
-    ^name = QueueConfiguration.name(qc)
-    ^durable = QueueConfiguration.durable(qc)
-    ^ttl = QueueConfiguration.ttl(qc)
-    ^max_priority = QueueConfiguration.max_priority(qc)
+    assert name == QueueConfiguration.name(qc)
+    assert durable == QueueConfiguration.durable(qc)
+    assert ttl == QueueConfiguration.ttl(qc)
+    assert max_priority == QueueConfiguration.max_priority(qc)
   end
 
   test "sets max_priority values that are too large to the max" do
     qc = QueueConfiguration.new("some_queue_name", max_priority: 500)
-    255 = QueueConfiguration.max_priority(qc)
+    assert 255 == QueueConfiguration.max_priority(qc)
   end
 
   test "builds empty arguments when neither ttl or max_priority are provided" do
-    ttl = 5000
     qc = QueueConfiguration.new("some_queue_name")
-    [] = QueueConfiguration.build_queue_arguments(qc, [])
+    assert [] == QueueConfiguration.build_queue_arguments(qc, [])
   end
 
   test "builds correct arguments when ttl and max_priority are provided" do
@@ -54,7 +53,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         max_priority: max_priority
       )
 
-    [{"x-expires", :long, ^ttl}, {"x-max-priority", :long, ^max_priority}] =
-      QueueConfiguration.build_queue_arguments(qc, [])
+    assert [{"x-expires", :long, ttl}, {"x-max-priority", :long, max_priority}] ==
+             QueueConfiguration.build_queue_arguments(qc, [])
   end
 end

--- a/test/gen_rmq/consumer/queue_configuration_test.exs
+++ b/test/gen_rmq/consumer/queue_configuration_test.exs
@@ -1,0 +1,60 @@
+defmodule GenRMQ.Consumer.QueueConfigurationTest do
+  use ExUnit.Case, async: true
+  alias GenRMQ.Consumer.QueueConfiguration
+
+  test "may be built with just a queue name" do
+    qc = QueueConfiguration.new("some_queue_name")
+    "some_queue_name" = QueueConfiguration.name(qc)
+  end
+
+  test "durable should default to true" do
+    qc = QueueConfiguration.new("some_queue_name")
+    true = QueueConfiguration.durable(qc)
+  end
+
+  test "may be built with all options" do
+    name = "some_queue_name"
+    ttl = 5000
+    durable = false
+    max_priority = 200
+
+    qc =
+      QueueConfiguration.new(
+        name,
+        durable,
+        ttl,
+        max_priority
+      )
+
+    ^name = QueueConfiguration.name(qc)
+    ^durable = QueueConfiguration.durable(qc)
+    ^ttl = QueueConfiguration.ttl(qc)
+    ^max_priority = QueueConfiguration.max_priority(qc)
+  end
+
+  test "sets max_priority values that are too large to the max" do
+    qc = QueueConfiguration.new("some_queue_name", max_priority: 500)
+    255 = QueueConfiguration.max_priority(qc)
+  end
+
+  test "builds empty arguments when neither ttl or max_priority are provided" do
+    ttl = 5000
+    qc = QueueConfiguration.new("some_queue_name")
+    [] = QueueConfiguration.build_queue_arguments(qc, [])
+  end
+
+  test "builds correct arguments when ttl and max_priority are provided" do
+    ttl = 5000
+    max_priority = 5
+
+    qc =
+      QueueConfiguration.new(
+        "some_queue_name",
+        ttl: ttl,
+        max_priority: max_priority
+      )
+
+    [{"x-expires", :long, ^ttl}, {"x-max-priority", :long, ^max_priority}] =
+      QueueConfiguration.build_queue_arguments(qc, [])
+  end
+end

--- a/test/gen_rmq_consumer_test.exs
+++ b/test/gen_rmq_consumer_test.exs
@@ -129,8 +129,8 @@ defmodule GenRMQ.ConsumerTest do
 
       Assert.repeatedly(fn ->
         assert Process.alive?(consumer_pid) == true
-        assert queue_count(context[:rabbit_conn], "#{state.config[:queue]}") == {:ok, 0}
-        assert queue_count(context[:rabbit_conn], "#{state.config[:queue]}_error") == {:error, :not_found}
+        assert queue_count(context[:rabbit_conn], "#{state.config[:queue].name}") == {:ok, 0}
+        assert queue_count(context[:rabbit_conn], "#{state.config[:queue].name}_error") == {:error, :not_found}
       end)
     end
   end
@@ -281,7 +281,7 @@ defmodule GenRMQ.ConsumerTest do
       publish_message(context[:rabbit_conn], context[:exchange], Jason.encode!(message), "routing_key_1")
 
       Assert.repeatedly(fn ->
-        assert queue_count(context[:rabbit_conn], "#{state.config[:queue]}_error") == {:ok, 1}
+        assert queue_count(context[:rabbit_conn], "#{state.config[:queue].name}_error") == {:ok, 1}
       end)
     end
 

--- a/test/support/consumer_shared_tests.ex
+++ b/test/support/consumer_shared_tests.ex
@@ -25,7 +25,7 @@ defmodule ConsumerSharedTests do
         publish_message(context[:rabbit_conn], context[:exchange], Jason.encode!(message))
 
         GenRMQ.Test.Assert.repeatedly(fn ->
-          assert queue_count(context[:rabbit_conn], "#{state.config[:queue]}_error") == {:ok, 1}
+          assert queue_count(context[:rabbit_conn], "#{state.config[:queue].name}_error") == {:ok, 1}
         end)
       end
     end
@@ -49,7 +49,7 @@ defmodule ConsumerSharedTests do
   defmacro terminate_after_queue_deletion_test do
     quote do
       test "should terminate after queue deletion", %{consumer: consumer_pid, state: state} do
-        AMQP.Queue.delete(state.out, state[:config][:queue])
+        AMQP.Queue.delete(state.out, state[:config][:queue].name)
 
         GenRMQ.Test.Assert.repeatedly(fn ->
           assert Process.alive?(consumer_pid) == false
@@ -61,7 +61,7 @@ defmodule ConsumerSharedTests do
   defmacro exit_signal_after_queue_deletion_test do
     quote do
       test "should send exit signal after queue deletion", %{consumer: consumer_pid, state: state} do
-        AMQP.Queue.delete(state.out, state[:config][:queue])
+        AMQP.Queue.delete(state.out, state[:config][:queue].name)
 
         assert_receive({:EXIT, ^consumer_pid, :cancelled})
       end
@@ -71,7 +71,7 @@ defmodule ConsumerSharedTests do
   defmacro close_connection_and_channels_after_deletion_test do
     quote do
       test "should close connection and channels after queue deletion", %{state: state} do
-        AMQP.Queue.delete(state.out, state[:config][:queue])
+        AMQP.Queue.delete(state.out, state[:config][:queue].name)
 
         GenRMQ.Test.Assert.repeatedly(fn ->
           assert Process.alive?(state.conn.pid) == false


### PR DESCRIPTION
Begin consumer options refactor.

Refs #134 

## Description
Begin refactoring of consumer settings.  This PR focusses specifically on consumer Queue settings.

It does not change the configuration API for consumers.

## Checklist
- [x] I have added unit tests to cover my changes.
- [x] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [x] I have updated the documentation accordingly
