### PR TITLE
Adding telemetry support to gen_rmq

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,73 +106,73 @@ It currently exposes the following events:
 
 - `[:gen_rmq, :publisher, :connection, :start]` - Dispatched by a GenRMQ publisher when a connection to RabbitMQ is started
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time}`
+  - Metadata: `%{exchange: String.t}`
 
 * `[:gen_rmq, :publisher, :connection, :stop]` - Dispatched by a GenRMQ publisher when a connection to RabbitMQ has been established
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time, duration: native_time}`
+  - Metadata: `%{exchange: String.t}`
 
 * `[:gen_rmq, :publisher, :connection, :down]` - Dispatched by a GenRMQ publisher when a connection to RabbitMQ has been lost
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time}`
+  - Metadata: `%{module: atom, reason: atom}`
 
 * `[:gen_rmq, :publisher, :message, :start]` - Dispatched by a GenRMQ publisher when a message is about to be published to RabbitMQ
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time}`
+  - Metadata: `%{exchange: String.t, message: String.t}`
 
 * `[:gen_rmq, :publisher, :message, :stop]` - Dispatched by a GenRMQ publisher when a message has been published to RabbitMQ
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time, duration: native_time}`
+  - Metadata: `%{exchange: String.t, message: String.t}`
 
 * `[:gen_rmq, :publisher, :message, :error]` - Dispatched by a GenRMQ publisher when a message failed to be published to RabbitMQ
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time, duration: native_time}`
+  - Metadata: `%{exchange: String.t, message: String.t, kind: atom, reason: atom}`
 
 * `[:gen_rmq, :consumer, :message, :ack]` - Dispatched by a GenRMQ consumer when a message has been acknowledged
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time}`
+  - Metadata: `%{message: String.t}`
 
 * `[:gen_rmq, :consumer, :message, :reject]` - Dispatched by a GenRMQ consumer when a message has been rejected
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time}`
+  - Metadata: `%{message: String.t, requeue: boolean}`
 
 * `[:gen_rmq, :consumer, :message, :start]` - Dispatched by a GenRMQ consumer when the processing of a message has begun
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time}`
+  - Metadata: `%{message: String.t, module: atom}`
 
 * `[:gen_rmq, :consumer, :message, :stop]` - Dispatched by a GenRMQ consumer when the processing of a message has completed
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time, duration: native_time}`
+  - Metadata: `%{message: String.t, module: atom}`
 
 * `[:gen_rmq, :consumer, :connection, :start]` - Dispatched by a GenRMQ consumer when a connection to RabbitMQ is started
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time}`
+  - Metadata: `%{module: atom, attempt: integer, queue: String.t, exchange: String.t, routing_key: String.t}`
 
 * `[:gen_rmq, :consumer, :connection, :stop]` - Dispatched by a GenRMQ consumer when a connection to RabbitMQ has been established
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time, duration: native_time}`
+  - Metadata: `%{module: atom, attempt: integer, queue: String.t, exchange: String.t, routing_key: String.t}`
 
 * `[:gen_rmq, :consumer, :connection, :error]` - Dispatched by a GenRMQ consumer when a connection to RabbitMQ could not be made
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time}`
+  - Metadata: `%{module: atom, attempt: integer, queue: String.t, exchange: String.t, routing_key: String.t, error: any}`
 
 * `[:gen_rmq, :consumer, :connection, :down]` - Dispatched by a GenRMQ consumer when a connection to RabbitMQ has been lost
 
-  - Measurement: `%{}`
-  - Metadata: `%{}`
+  - Measurement: `%{time: System.monotonic_time}`
+  - Metadata: `%{module: atom, reason: atom}`
 
 ## Running tests
 

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -364,11 +364,11 @@ defmodule GenRMQ.Consumer do
     exchange = config[:exchange]
     routing_key = config[:routing_key]
 
-    emit_connect_start_event(start_time, module, attempt, queue, exchange, routing_key)
+    emit_connection_start_event(start_time, module, attempt, queue, exchange, routing_key)
 
     case Connection.open(config[:uri]) do
       {:ok, conn} ->
-        emit_connect_stop_event(start_time, module, attempt, queue, exchange, routing_key)
+        emit_connection_stop_event(start_time, module, attempt, queue, exchange, routing_key)
         Process.monitor(conn.pid)
         Map.put(state, :conn, conn)
 
@@ -378,7 +378,7 @@ defmodule GenRMQ.Consumer do
             "#{inspect(strip_key(config, :uri))}, reason #{inspect(e)}"
         )
 
-        emit_connect_error_event(start_time, module, attempt, queue, exchange, routing_key, e)
+        emit_connection_error_event(start_time, module, attempt, queue, exchange, routing_key, e)
 
         retry_delay_fn = config[:retry_delay_function] || (&linear_delay/1)
         next_attempt = attempt + 1
@@ -486,7 +486,7 @@ defmodule GenRMQ.Consumer do
     :telemetry.execute([:gen_rmq, :consumer, :connection, :down], measurements, metadata)
   end
 
-  defp emit_connect_start_event(start_time, module, attempt, queue, exchange, routing_key) do
+  defp emit_connection_start_event(start_time, module, attempt, queue, exchange, routing_key) do
     measurements = %{time: start_time}
 
     metadata = %{
@@ -500,7 +500,7 @@ defmodule GenRMQ.Consumer do
     :telemetry.execute([:gen_rmq, :consumer, :connection, :start], measurements, metadata)
   end
 
-  defp emit_connect_stop_event(start_time, module, attempt, queue, exchange, routing_key) do
+  defp emit_connection_stop_event(start_time, module, attempt, queue, exchange, routing_key) do
     stop_time = System.monotonic_time()
     measurements = %{time: stop_time, duration: stop_time - start_time}
 
@@ -515,7 +515,7 @@ defmodule GenRMQ.Consumer do
     :telemetry.execute([:gen_rmq, :consumer, :connection, :stop], measurements, metadata)
   end
 
-  defp emit_connect_error_event(start_time, module, attempt, queue, exchange, routing_key, error) do
+  defp emit_connection_error_event(start_time, module, attempt, queue, exchange, routing_key, error) do
     stop_time = System.monotonic_time()
     measurements = %{time: stop_time, duration: stop_time - start_time}
 

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -497,7 +497,7 @@ defmodule GenRMQ.Consumer do
       routing_key: routing_key
     }
 
-    :telemetry.execute([:gen_rmq, :consumer, :connect, :start], measurements, metadata)
+    :telemetry.execute([:gen_rmq, :consumer, :connection, :start], measurements, metadata)
   end
 
   defp emit_connect_stop_event(start_time, module, attempt, queue, exchange, routing_key) do
@@ -512,7 +512,7 @@ defmodule GenRMQ.Consumer do
       routing_key: routing_key
     }
 
-    :telemetry.execute([:gen_rmq, :consumer, :connect, :stop], measurements, metadata)
+    :telemetry.execute([:gen_rmq, :consumer, :connection, :stop], measurements, metadata)
   end
 
   defp emit_connect_error_event(start_time, module, attempt, queue, exchange, routing_key, error) do
@@ -528,7 +528,7 @@ defmodule GenRMQ.Consumer do
       error: error
     }
 
-    :telemetry.execute([:gen_rmq, :consumer, :connect, :error], measurements, metadata)
+    :telemetry.execute([:gen_rmq, :consumer, :connection, :error], measurements, metadata)
   end
 
   defp strip_key(keyword_list, key) do

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -358,9 +358,9 @@ defmodule GenRMQ.Consumer do
 
   defp get_connection(%{config: config, module: module, reconnect_attempt: attempt} = state) do
     start_time = System.monotonic_time()
-    queue = Keyword.get(config, :queue)
-    exchange = Keyword.get(config, :exchange)
-    routing_key = Keyword.get(config, :routing_key)
+    queue = config[:queue]
+    exchange = config[:exchange]
+    routing_key = config[:routing_key]
 
     emit_connect_start_event(start_time, module, attempt, queue, exchange, routing_key)
 
@@ -470,7 +470,7 @@ defmodule GenRMQ.Consumer do
 
   defp emit_message_stop_event(start_time, message) do
     stop_time = System.monotonic_time()
-    measurements = %{time: start_time, duration: stop_time - start_time}
+    measurements = %{time: stop_time, duration: stop_time - start_time}
     metadata = %{message: message}
 
     :telemetry.execute([:gen_rmq, :consumer, :message, :stop], measurements, metadata)
@@ -492,7 +492,7 @@ defmodule GenRMQ.Consumer do
 
   defp emit_connect_stop_event(start_time, module, attempt, queue, exchange, routing_key) do
     stop_time = System.monotonic_time()
-    measurements = %{time: start_time, duration: stop_time - start_time}
+    measurements = %{time: stop_time, duration: stop_time - start_time}
 
     metadata = %{
       module: module,
@@ -507,7 +507,7 @@ defmodule GenRMQ.Consumer do
 
   defp emit_connect_error_event(start_time, module, attempt, queue, exchange, routing_key, error) do
     stop_time = System.monotonic_time()
-    measurements = %{time: start_time, duration: stop_time - start_time}
+    measurements = %{time: stop_time, duration: stop_time - start_time}
 
     metadata = %{
       module: module,

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -310,7 +310,7 @@ defmodule GenRMQ.Publisher do
     start_time = System.monotonic_time()
     exchange = config[:exchange]
 
-    emit_publish_connection_start_event(start_time, exchange)
+    emit_connection_start_event(start_time, exchange)
 
     {:ok, conn} = connect(state)
     {:ok, channel} = Channel.open(conn)
@@ -319,7 +319,7 @@ defmodule GenRMQ.Publisher do
     with_confirmations = Keyword.get(config, :enable_confirmations, false)
     :ok = activate_confirmations(channel, with_confirmations)
 
-    emit_publish_connection_stop_event(start_time, exchange)
+    emit_connection_stop_event(start_time, exchange)
 
     {:ok, %{channel: channel, module: module, config: config, conn: conn}}
   end
@@ -332,14 +332,14 @@ defmodule GenRMQ.Publisher do
     :telemetry.execute([:gen_rmq, :publisher, :connection, :down], measurements, metadata)
   end
 
-  defp emit_publish_connection_start_event(start_time, exchange) do
+  defp emit_connection_start_event(start_time, exchange) do
     measurements = %{time: start_time}
     metadata = %{exchange: exchange}
 
     :telemetry.execute([:gen_rmq, :publisher, :connection, :start], measurements, metadata)
   end
 
-  defp emit_publish_connection_stop_event(start_time, exchange) do
+  defp emit_connection_stop_event(start_time, exchange) do
     stop_time = System.monotonic_time()
     measurements = %{time: stop_time, duration: stop_time - start_time}
     metadata = %{exchange: exchange}

--- a/mix.exs
+++ b/mix.exs
@@ -42,6 +42,7 @@ defmodule GenRMQ.Mixfile do
   defp deps do
     [
       {:amqp, "~> 1.1"},
+      {:telemetry, "~> 0.4.1"},
       {:credo, "~> 1.0", only: :dev},
       {:excoveralls, "~> 0.12.0", only: :test},
       {:jason, "~> 1.1", only: [:dev, :test]},

--- a/mix.lock
+++ b/mix.lock
@@ -26,5 +26,6 @@
   "ranch_proxy_protocol": {:hex, :ranch_proxy_protocol, "2.1.1", "3c4723327166d2d63c0405f4914e2e471c6de362cc844e9b203af5763e7c9d25", [:rebar3], [{:ranch, "1.6.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "recon": {:hex, :recon, "2.5.0", "2f7fcbec2c35034bade2f9717f77059dc54eb4e929a3049ca7ba6775c0bd66cd", [:mix, :rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/gen_rmq_consumer_test.exs
+++ b/test/gen_rmq_consumer_test.exs
@@ -344,14 +344,10 @@ defmodule GenRMQ.ConsumerTest do
       :telemetry.attach_many(
         "#{test}",
         [
-          [:gen_rmq, :consumer, :message, :ack],
-          [:gen_rmq, :consumer, :message, :reject],
           [:gen_rmq, :consumer, :message, :start],
           [:gen_rmq, :consumer, :message, :stop],
           [:gen_rmq, :consumer, :connection, :start],
-          [:gen_rmq, :consumer, :connection, :stop],
-          [:gen_rmq, :consumer, :connection, :error],
-          [:gen_rmq, :consumer, :connection, :down]
+          [:gen_rmq, :consumer, :connection, :stop]
         ],
         fn name, measurements, metadata, _ ->
           send(self, {:telemetry_event, name, measurements, metadata})

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -329,8 +329,10 @@ defmodule GenRMQ.PublisherTest do
     end
 
     test "should be emitted when the publisher start and completes setup" do
-      assert_receive {:telemetry_event, [:gen_rmq, :publisher, :setup, :start], %{time: _}, %{exchange: _}}
-      assert_receive {:telemetry_event, [:gen_rmq, :publisher, :setup, :stop], %{time: _, duration: _}, %{exchange: _}}
+      assert_receive {:telemetry_event, [:gen_rmq, :publisher, :connection, :start], %{time: _}, %{exchange: _}}
+
+      assert_receive {:telemetry_event, [:gen_rmq, :publisher, :connection, :stop], %{time: _, duration: _},
+                      %{exchange: _}}
     end
 
     test "should be emitted when the publisher starts and completes the publishing of a message",
@@ -356,11 +358,10 @@ defmodule GenRMQ.PublisherTest do
       :telemetry.attach_many(
         "#{test}",
         [
-          [:gen_rmq, :publisher, :setup, :start],
-          [:gen_rmq, :publisher, :setup, :stop],
+          [:gen_rmq, :publisher, :connection, :start],
+          [:gen_rmq, :publisher, :connection, :stop],
           [:gen_rmq, :publisher, :message, :start],
-          [:gen_rmq, :publisher, :message, :stop],
-          [:gen_rmq, :publisher, :message, :error]
+          [:gen_rmq, :publisher, :message, :stop]
         ],
         fn name, measurements, metadata, _ ->
           send(self, {:telemetry_event, name, measurements, metadata})


### PR DESCRIPTION
## Description
This PR integrates telemetry into gen_rmq (closing out #5) and provides event dispatching for both consumers and producers. The following events are emitted:

```elixir
[:gen_rmq, :publisher, :connection, :start]
[:gen_rmq, :publisher, :connection, :stop]
[:gen_rmq, :publisher, :connection, :down]
[:gen_rmq, :publisher, :message, :start]
[:gen_rmq, :publisher, :message, :stop]
[:gen_rmq, :publisher, :message, :error]
[:gen_rmq, :consumer, :message, :ack]
[:gen_rmq, :consumer, :message, :reject]
[:gen_rmq, :consumer, :message, :start]
[:gen_rmq, :consumer, :message, :stop]
[:gen_rmq, :consumer, :connection, :start]
[:gen_rmq, :consumer, :connection, :stop]
[:gen_rmq, :consumer, :connection, :error]
[:gen_rmq, :consumer, :connection, :down]
```

With this in place, you can leverage https://hexdocs.pm/telemetry_metrics/Telemetry.Metrics.html to get counters in place for message through put and histograms in place for message processing duration.

## Checklist
- [x] I have added unit tests to cover my changes. (Will add tests once design is approved)
- [X] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [x] I have updated the documentation accordingly (Will add documentation once design is approved)
