### PR TITLE
Handle redeclaration errors from the broker

### DIFF
--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -317,6 +317,18 @@ defmodule GenRMQ.Consumer do
     Connection.close(conn)
   end
 
+  @doc false
+  @impl GenServer
+  def terminate({{:shutdown, {:server_initiated_close, error_code, reason}}, _}, %{module: module}) do
+    Logger.error("[#{module}]: Terminating consumer, error_code: #{inspect(error_code)}, reason: #{inspect(reason)}")
+  end
+
+  @doc false
+  @impl GenServer
+  def terminate(reason, %{module: module}) do
+    Logger.error("[#{module}]: Terminating consumer, unexpected reason: #{inspect(reason)}")
+  end
+
   ##############################################################################
   # Helpers
   ##############################################################################

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -302,6 +302,18 @@ defmodule GenRMQ.Publisher do
     Connection.close(conn)
   end
 
+  @doc false
+  @impl GenServer
+  def terminate({{:shutdown, {:server_initiated_close, error_code, reason}}, _}, %{module: module}) do
+    Logger.error("[#{module}]: Terminating publisher, error_code: #{inspect(error_code)}, reason: #{inspect(reason)}")
+  end
+
+  @doc false
+  @impl GenServer
+  def terminate(reason, %{module: module}) do
+    Logger.error("[#{module}]: Terminating publisher, unexpected reason: #{inspect(reason)}")
+  end
+
   ##############################################################################
   # Helpers
   ##############################################################################

--- a/lib/rabbit_case.ex
+++ b/lib/rabbit_case.ex
@@ -12,6 +12,8 @@ defmodule GenRMQ.RabbitCase do
         AMQP.Connection.open(uri)
       end
 
+      def open_channel(connection), do: AMQP.Channel.open(connection)
+
       def publish_message(conn, exchange, message, routing_key \\ "#", meta \\ []) do
         {:ok, channel} = AMQP.Channel.open(conn)
         GenRMQ.Binding.declare_exchange(channel, exchange)

--- a/test/support/test_consumers.ex
+++ b/test/support/test_consumers.ex
@@ -280,4 +280,26 @@ defmodule TestConsumer do
       GenRMQ.Consumer.ack(message)
     end
   end
+
+  defmodule RedeclaringExistingExchange do
+    @moduledoc false
+    @behaviour GenRMQ.Consumer
+
+    def existing_exchange, do: "existing_direct_exchange"
+    def init() do
+      [
+        queue: "gen_rmq_in_queue_" <> existing_exchange(),
+        exchange: existing_exchange(),
+        prefetch_count: "10",
+        uri: "amqp://guest:guest@localhost:5672",
+        queue_ttl: 1000
+      ]
+    end
+
+    def consumer_tag() do
+      "TestConsumer.RedeclaringExistingExchange"
+    end
+
+    def handle_message(_), do: :ok
+  end
 end

--- a/test/support/test_publishers.ex
+++ b/test/support/test_publishers.ex
@@ -12,6 +12,21 @@ defmodule TestPublisher do
     end
   end
 
+  defmodule RedeclaringExistingExchange do
+    @moduledoc false
+    @behaviour GenRMQ.Publisher
+
+    def existing_exchange, do: "existing_direct_exchange"
+
+    def init() do
+      [
+        exchange: existing_exchange(),
+        uri: "amqp://guest:guest@localhost:5672",
+        app_id: :my_app_id
+      ]
+    end
+  end
+
   defmodule WithConfirmations do
     @moduledoc false
     @behaviour GenRMQ.Publisher


### PR DESCRIPTION
RabbitMQ will return an error, whenever clients try to redeclare an
existing resource with different parameters, for example:
* an existing exchange with different type

Currently, terminate callbacks are not matching this specific error message,
so publishers and consumers will crash with: `FunctionClauseError`.
This makes it hard to understand what exactly has happened:
https://github.com/meltwater/gen_rmq/issues/142

With these changes:
* terminate callbacks will be called
* corresponding error will be logged

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
