### PR TITLE
Connection option for Consumer and Producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ defmodule Consumer do
       exchange: "gen_rmq_exchange",
       routing_key: "#",
       prefetch_count: "10",
-      uri: "amqp://guest:guest@localhost:5672",
+      connection: "amqp://guest:guest@localhost:5672",
       retry_delay_function: fn attempt -> :timer.sleep(2000 * attempt) end
     ]
   end
@@ -88,7 +88,7 @@ defmodule Publisher do
   def init() do
     [
       exchange: "gen_rmq_exchange",
-      uri: "amqp://guest:guest@localhost:5672"
+      connection: "amqp://guest:guest@localhost:5672"
     ]
   end
 end

--- a/examples/consumer.ex
+++ b/examples/consumer.ex
@@ -42,7 +42,7 @@ defmodule ExampleConsumer do
       exchange: "example_exchange",
       routing_key: "routing_key.#",
       prefetch_count: "10",
-      uri: "amqp://guest:guest@localhost:5672"
+      connection: "amqp://guest:guest@localhost:5672"
     ]
   end
 

--- a/examples/publisher.ex
+++ b/examples/publisher.ex
@@ -26,7 +26,7 @@ defmodule ExamplePublisher do
   def init() do
     [
       exchange: "example_exchange",
-      uri: "amqp://guest:guest@localhost:5672"
+      connection: "amqp://guest:guest@localhost:5672"
     ]
   end
 end

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -27,7 +27,7 @@ defmodule GenRMQ.Consumer do
   ## Return values
   ### Mandatory:
 
-  `connection` - RabbitMQ connection options. Accepts same options as AMQP-library's Connection.open().
+  `connection` - RabbitMQ connection options. Accepts same arguments as AMQP-library's [Connection.open/2](https://hexdocs.pm/amqp/AMQP.Connection.html#open/2).
 
   `queue` - the name of the queue to consume. If it does not exist, it will be created.
 
@@ -98,7 +98,7 @@ defmodule GenRMQ.Consumer do
 
   """
   @callback init() :: [
-              connection: list,
+              connection: keyword | {String.t(), String.t()} | :undefined | keyword,
               queue: String.t(),
               exchange: GenRMQ.Binding.exchange(),
               routing_key: [String.t()] | String.t(),

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -39,12 +39,14 @@ defmodule GenRMQ.Publisher do
   ## Return values
   ### Mandatory:
 
-  `uri` - RabbitMQ uri
+  `connection` - RabbitMQ connection options. Accepts same options as AMQP-library's Connection.open().
 
   `exchange` - name or `{type, name}` of the target exchange. If it does not exist, it will be created.
   For valid exchange types see `GenRMQ.Binding`.
 
   ### Optional:
+
+  `uri` - RabbitMQ uri. Deprecated. Please use `connection`.
 
   `app_id` - publishing application ID. By default it is `:gen_rmq`.
 
@@ -57,7 +59,8 @@ defmodule GenRMQ.Publisher do
   def init() do
     [
       exchange: "gen_rmq_exchange",
-      uri: "amqp://guest:guest@localhost:5672"
+      connection: "amqp://guest:guest@localhost:5672",
+      uri: "amqp://guest:guest@localhost:5672",
       app_id: :my_app_id,
       enable_confirmations: true,
       max_confirmation_wait_time: 5_000
@@ -67,6 +70,7 @@ defmodule GenRMQ.Publisher do
 
   """
   @callback init() :: [
+              connection: list,
               exchange: GenRMQ.Binding.exchange(),
               uri: String.t(),
               app_id: atom,
@@ -319,6 +323,7 @@ defmodule GenRMQ.Publisher do
   ##############################################################################
 
   defp setup_publisher(%{module: module, config: config} = state) do
+    state = Map.put(state, :config, parse_config(config))
     start_time = System.monotonic_time()
     exchange = config[:exchange]
 
@@ -334,6 +339,11 @@ defmodule GenRMQ.Publisher do
     emit_connection_stop_event(start_time, exchange)
 
     {:ok, %{channel: channel, module: module, config: config, conn: conn}}
+  end
+
+  defp parse_config(config) do
+    config
+    |> Keyword.put(:connection, Keyword.get(config, :connection, config[:uri]))
   end
 
   defp emit_connection_down_event(module, reason) do
@@ -400,7 +410,7 @@ defmodule GenRMQ.Publisher do
   defp publish_result(error, _), do: error
 
   defp connect(%{module: module, config: config} = state) do
-    case Connection.open(config[:uri]) do
+    case Connection.open(config[:connection]) do
       {:ok, conn} ->
         Process.monitor(conn.pid)
         {:ok, conn}

--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -39,7 +39,7 @@ defmodule GenRMQ.Publisher do
   ## Return values
   ### Mandatory:
 
-  `connection` - RabbitMQ connection options. Accepts same options as AMQP-library's Connection.open().
+  `connection` - RabbitMQ connection options. Accepts same arguments as AMQP-library's [Connection.open/2](https://hexdocs.pm/amqp/AMQP.Connection.html#open/2).
 
   `exchange` - name or `{type, name}` of the target exchange. If it does not exist, it will be created.
   For valid exchange types see `GenRMQ.Binding`.
@@ -70,7 +70,7 @@ defmodule GenRMQ.Publisher do
 
   """
   @callback init() :: [
-              connection: list,
+              connection: keyword | {String.t(), String.t()} | :undefined | keyword,
               exchange: GenRMQ.Binding.exchange(),
               uri: String.t(),
               app_id: atom,
@@ -342,8 +342,9 @@ defmodule GenRMQ.Publisher do
   end
 
   defp parse_config(config) do
-    config
-    |> Keyword.put(:connection, Keyword.get(config, :connection, config[:uri]))
+    # Backwards compatibility support
+    # Use connection-keyword if it's set, otherwise use uri-keyword
+    Keyword.put(config, :connection, Keyword.get(config, :connection, config[:uri]))
   end
 
   defp emit_connection_down_event(module, reason) do

--- a/lib/rabbit_case.ex
+++ b/lib/rabbit_case.ex
@@ -8,8 +8,8 @@ defmodule GenRMQ.RabbitCase do
     quote do
       use AMQP
 
-      def rmq_open(uri) do
-        AMQP.Connection.open(uri)
+      def rmq_open(connection) do
+        AMQP.Connection.open(connection)
       end
 
       def open_channel(connection), do: AMQP.Channel.open(connection)
@@ -39,14 +39,14 @@ defmodule GenRMQ.RabbitCase do
         {:ok, Jason.decode!(payload), meta}
       end
 
-      def purge_queues(uri, queues) do
-        {:ok, conn} = rmq_open(uri)
+      def purge_queues(connection, queues) do
+        {:ok, conn} = rmq_open(connection)
         Enum.each(queues, &purge_queue(conn, &1))
         AMQP.Connection.close(conn)
       end
 
-      def purge_queues!(uri, queues) do
-        {:ok, conn} = rmq_open(uri)
+      def purge_queues!(connection, queues) do
+        {:ok, conn} = rmq_open(connection)
         Enum.each(queues, &purge_queue!(conn, &1))
         AMQP.Connection.close(conn)
       end

--- a/test/gen_rmq_consumer_test.exs
+++ b/test/gen_rmq_consumer_test.exs
@@ -18,10 +18,10 @@ defmodule GenRMQ.ConsumerTest do
   alias TestConsumer.WithMultiBindingExchange
   alias TestConsumer.RedeclaringExistingExchange
 
-  @uri "amqp://guest:guest@localhost:5672"
+  @connection "amqp://guest:guest@localhost:5672"
 
   setup_all do
-    {:ok, conn} = rmq_open(@uri)
+    {:ok, conn} = rmq_open(@connection)
     {:ok, rabbit_conn: conn}
   end
 

--- a/test/gen_rmq_publisher_test.exs
+++ b/test/gen_rmq_publisher_test.exs
@@ -9,19 +9,19 @@ defmodule GenRMQ.PublisherTest do
   alias TestPublisher.WithConfirmations
   alias TestPublisher.RedeclaringExistingExchange
 
-  @uri "amqp://guest:guest@localhost:5672"
+  @connection "amqp://guest:guest@localhost:5672"
   @exchange "gen_rmq_out_exchange"
   @out_queue "gen_rmq_out_queue"
   @invalid_queue "invalid_queue"
 
   setup_all do
-    {:ok, conn} = rmq_open(@uri)
+    {:ok, conn} = rmq_open(@connection)
     :ok = setup_out_queue(conn, @out_queue, @exchange)
     {:ok, rabbit_conn: conn, out_queue: @out_queue}
   end
 
   setup do
-    purge_queues(@uri, [@out_queue])
+    purge_queues(@connection, [@out_queue])
   end
 
   describe "start_link/2" do

--- a/test/support/test_consumers.ex
+++ b/test/support/test_consumers.ex
@@ -9,7 +9,7 @@ defmodule TestConsumer do
         exchange: "gen_rmq_in_exchange",
         routing_key: "#",
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         queue_ttl: 1000
       ]
     end
@@ -39,7 +39,7 @@ defmodule TestConsumer do
         exchange: "gen_rmq_in_exchange",
         routing_key: "#",
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         concurrency: false,
         queue_ttl: 1000
       ]
@@ -68,7 +68,7 @@ defmodule TestConsumer do
         exchange: "does_not_matter_exchange",
         routing_key: "#",
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         reconnect: false,
         queue_ttl: 1000
       ]
@@ -92,7 +92,7 @@ defmodule TestConsumer do
         exchange: "gen_rmq_in_exchange_no_deadletter",
         routing_key: "#",
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         queue_ttl: 1000,
         deadletter: false
       ]
@@ -117,7 +117,7 @@ defmodule TestConsumer do
         exchange: "gen_rmq_in_exchange_custom_deadletter",
         routing_key: "#",
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         queue_ttl: 1000,
         deadletter_queue: "dl_queue",
         deadletter_exchange: "dl_exchange",
@@ -144,7 +144,7 @@ defmodule TestConsumer do
         exchange: "gen_rmq_in_exchange_with_prio",
         routing_key: "#",
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         queue_ttl: 1000,
         queue_max_priority: 100
       ]
@@ -171,7 +171,7 @@ defmodule TestConsumer do
         exchange: {:topic, "gen_rmq_in_wt_exchange"},
         routing_key: "#",
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         queue_ttl: 1000
       ]
     end
@@ -201,7 +201,7 @@ defmodule TestConsumer do
         exchange: {:direct, "gen_rmq_in_wd_exchange"},
         routing_key: "#",
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         queue_ttl: 1000
       ]
     end
@@ -231,7 +231,7 @@ defmodule TestConsumer do
         exchange: {:fanout, "gen_rmq_in_wf_exchange"},
         routing_key: "#",
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         queue_ttl: 1000
       ]
     end
@@ -261,7 +261,7 @@ defmodule TestConsumer do
         exchange: {:direct, "gen_rmq_in_mb_exchange"},
         routing_key: ["routing_key_1", "routing_key_2"],
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         queue_ttl: 1000
       ]
     end

--- a/test/support/test_publishers.ex
+++ b/test/support/test_publishers.ex
@@ -6,7 +6,7 @@ defmodule TestPublisher do
     def init() do
       [
         exchange: "gen_rmq_out_exchange",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         app_id: :my_app_id
       ]
     end
@@ -34,7 +34,7 @@ defmodule TestPublisher do
     def init() do
       [
         exchange: "gen_rmq_out_exchange",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         app_id: :my_app_id,
         enable_confirmations: true
       ]


### PR DESCRIPTION
## Description
Added new keyword 'connection' to both Consumer's and Producer's inits.

This accepts same values as AMQP-library's Connection.open/2

Using 'connection' keyword instead of 'uri' tells user that more values than just the connection string can be passed.

This would be a better fix for issue #141 

The actual behavior is same as with 'uri' keyword. No actual logic changes were made.

The old 'uri' keyword can still be used.

## Examples
```elixir
# Using just connection string
def init() do
      [
        queue: "gen_rmq_wf_in_queue",
        exchange: {:fanout, "gen_rmq_in_wf_exchange"},
        routing_key: "#",
        prefetch_count: "10",
        connection: "amqp://guest:guest@localhost:5672",
        queue_ttl: 1000
      ]

# Using more options
def init() do
      [
        queue: "gen_rmq_wf_in_queue",
        exchange: {:fanout, "gen_rmq_in_wf_exchange"},
        routing_key: "#",
        prefetch_count: "10",
        connection: [host: "localhost", port: 5672, username: "guest", password: "guest"],
        queue_ttl: 1000
      ]
```

## Checklist
- [x] I have updated the documentation accordingly
