### PR TITLE
Queue options on init

### DIFF
--- a/examples/consumer_options.ex
+++ b/examples/consumer_options.ex
@@ -1,0 +1,76 @@
+defmodule ExampleConsumerOptions do
+  @moduledoc """
+  Example GenRMQ.Consumer implementation.
+
+  Sample usage:
+  ```
+  MIX_ENV=test iex -S mix
+  iex(1)> ExampleConsumerOptions.start_link()
+  ```
+  """
+  @behaviour GenRMQ.Consumer
+
+  require Logger
+
+  alias GenRMQ.Message
+
+  ##############################################################################
+  # Consumer API
+  ##############################################################################
+
+  def start_link() do
+    GenRMQ.Consumer.start_link(__MODULE__, name: __MODULE__)
+  end
+
+  def ack(%Message{attributes: %{delivery_tag: tag}} = message) do
+    Logger.debug("Message successfully processed. Tag: #{tag}")
+    GenRMQ.Consumer.ack(message)
+  end
+
+  def reject(%Message{attributes: %{delivery_tag: tag}} = message, requeue \\ true) do
+    Logger.info("Rejecting message, tag: #{tag}, requeue: #{requeue}")
+    GenRMQ.Consumer.reject(message, requeue)
+  end
+
+  ##############################################################################
+  # GenRMQ.Consumer callbacks
+  ##############################################################################
+
+  def init() do
+    [
+      queue: "example_queue",
+      queue_options: [
+        durable: true,
+        arguments: [
+          {"x-queue-type", :longstr ,"quorum"},
+        ]
+      ],
+      exchange: "example_exchange",
+      routing_key: "routing_key.#",
+      prefetch_count: "10",
+      uri: "amqp://guest:guest@localhost:5672",
+      deadletter_queue_options: [
+        durable: true,
+        arguments: [
+          {"x-queue-type", :longstr ,"quorum"},
+        ]
+      ],
+      deadletter_exchange: "deadletter_exchange",
+      deadletter_routing_key: "rk",
+    ]
+  end
+
+  def handle_message(%Message{} = message) do
+    Logger.info("Received message: #{inspect(message)}")
+    ack(message)
+  rescue
+    exception ->
+      Logger.error(Exception.format(:error, exception, System.stacktrace()))
+      reject(message, false)
+  end
+
+  def consumer_tag() do
+    {:ok, hostname} = :inet.gethostname()
+    "#{hostname}-example-consumer"
+  end
+end

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -126,7 +126,7 @@ defmodule GenRMQ.Consumer do
   @callback init() :: [
               connection: keyword | {String.t(), String.t()} | :undefined | keyword,
               queue: String.t(),
-              queue_options: list,
+              queue_options: keyword,
               exchange: GenRMQ.Binding.exchange(),
               routing_key: [String.t()] | String.t(),
               prefetch_count: String.t(),
@@ -137,7 +137,7 @@ defmodule GenRMQ.Consumer do
               reconnect: boolean,
               deadletter: boolean,
               deadletter_queue: String.t(),
-              deadletter_queue_options: list,
+              deadletter_queue_options: keyword,
               deadletter_exchange: String.t(),
               deadletter_routing_key: String.t(),
               queue_max_priority: integer

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -367,10 +367,8 @@ defmodule GenRMQ.Consumer do
   defp parse_config(config) do
     queue_name = Keyword.fetch!(config, :queue)
 
-    queue_settings =
-      QueueConfiguration.setup(queue_name, config)
-
-    Keyword.put(config, :queue, queue_settings)
+    config
+    |> Keyword.put(:queue, QueueConfiguration.setup(queue_name, config))
     |> Keyword.put(:connection, Keyword.get(config, :connection, config[:uri]))
   end
 

--- a/lib/gen_rmq/consumer/queue_configuration.ex
+++ b/lib/gen_rmq/consumer/queue_configuration.ex
@@ -7,90 +7,149 @@ defmodule GenRMQ.Consumer.QueueConfiguration do
   with respect to the consumer configuration API.
   """
 
-  defstruct name: nil,
-            ttl: nil,
-            max_priority: nil,
-            durable: true
-
-  @type t :: %__MODULE__{
-          name: String.t(),
-          ttl: nil | pos_integer,
-          max_priority: nil | pos_integer,
-          durable: boolean
-        }
-
-  @type queue_options ::
-          []
-          | [durable: boolean]
-          | [durable: boolean, max_priority: pos_integer]
-          | [durable: boolean, ttl: pos_integer]
-          | [max_priority: pos_integer]
-          | [max_priority: pos_integer, ttl: pos_integer]
-          | [durable: boolean, max_priority: pos_integer, ttl: pos_integer]
-
-  @spec new(String.t(), queue_options) :: t
-  def new(name, args \\ []) do
-    queue_ttl = Keyword.get(args, :ttl, nil)
-    queue_mp = Keyword.get(args, :max_priority, nil)
-    durable = Keyword.get(args, :durable, true)
-
-    %__MODULE__{
-      name: name,
-      ttl: queue_ttl,
-      max_priority: set_max_priority_to_highest_value(queue_mp),
-      durable: durable
-    }
-  end
-
-  @spec new(String.t(), boolean, nil | pos_integer, nil | pos_integer) :: t
-  def new(name, durable, ttl, mp) do
-    %__MODULE__{
-      name: name,
-      ttl: ttl,
-      max_priority: set_max_priority_to_highest_value(mp),
-      durable: durable
-    }
-  end
-
-  @spec name(t) :: String.t()
-  def name(%__MODULE__{name: n}), do: n
-
-  @spec durable(t) :: boolean
-  def durable(%__MODULE__{durable: d}), do: d
-
-  @spec ttl(t) :: nil | pos_integer
-  def ttl(%__MODULE__{ttl: ttl_v}), do: ttl_v
-
-  @spec max_priority(t) :: nil | pos_integer
-  def max_priority(%__MODULE__{max_priority: mp}), do: mp
-
-  def build_queue_arguments(%__MODULE__{} = qc, arguments) do
-    args_with_priority = setup_priority(arguments, qc.max_priority)
-
-    qc
-    |> build_ttl_arguments(args_with_priority)
-  end
-
-  def build_ttl_arguments(%__MODULE__{} = qc, arguments) do
-    setup_ttl(arguments, qc.ttl)
-  end
-
-  defp setup_ttl(arguments, nil), do: arguments
-  defp setup_ttl(arguments, ttl), do: [{"x-expires", :long, ttl} | arguments]
-
-  defp setup_priority(arguments, max_priority) when is_integer(max_priority),
-    do: [{"x-max-priority", :long, max_priority} | arguments]
-
-  defp setup_priority(arguments, _), do: arguments
-
   @max_priority 255
 
-  defp set_max_priority_to_highest_value(nil), do: nil
+  def setup(queue_name, config) do
+    exchange = GenRMQ.Binding.exchange_name(config[:exchange])
+    options = options(:queue_options, config)
+
+    dead_letter = [
+        create: Keyword.get(config, :deadletter, true),
+        name: Keyword.get(config, :deadletter_queue, "#{queue_name}_error"),
+        exchange: Keyword.get(config, :deadletter_exchange, "#{exchange}.deadletter"),
+        routing_key: Keyword.get(config, :deadletter_routing_key, "#"),
+        options: options(:deadletter_queue_options, config)
+    ]
+
+    return(queue_name, options, dead_letter)
+  end
+
+  defp options(queue_opts_word, config) do
+    [
+      durable: Keyword.get(config, :queue_durable, true),
+      max_priority: Keyword.get(config, :queue_max_priority, nil),
+      ttl: Keyword.get(config, :queue_ttl, nil)
+    ]
+    |> combine_options(Keyword.get(config, queue_opts_word, []))
+  end
+
+  defp combine_options(word_list, []) do
+    word_list
+  end
+  defp combine_options(word_list, option_list) do
+    # Combine two keyword lists together.
+    #
+    # Since queue_options and dead_letter_queue_options
+    # keywords on init can contain queue ttl and max
+    # priority as arguments, and these options will
+    # be used instead of queue_ttl and queue_max_priority
+    # keywords, we must check if these arguments
+    # are present.
+    #
+    # If option_list's arguments has "x-expires" and
+    # word_list has "ttl", then remove "ttl"
+    #
+    # If option_list's arguments has "x-max-priority" and
+    # word_list has "max_priority", then remove "max_priority"
+    #
+    # This is done in order to be backwards compatible.
+    # If one day those two keywords are removed from the
+    # init, then this function can be removed as well.
+    word_list
+    |> remove_keyword(option_list[:arguments], %{name: "x-expires", word: :ttl})
+    |> remove_keyword(option_list[:arguments], %{name: "x-max-priority", word: :max_priority})
+    |> Keyword.merge(option_list)
+  end
+
+  defp remove_keyword(word_list, option_arguments, argument) do
+    case Enum.find(option_arguments, fn arg -> elem(arg, 0) == argument.name end) do
+      nil -> word_list
+      _ -> Keyword.delete(word_list, argument.word)
+    end
+  end
+
+  defp return(name, options, dead_letter) do
+    # dead_letter_options and options variables can contain
+    # queue declare options as defined in
+    # https://hexdocs.pm/amqp/AMQP.Queue.html#declare/3
+    dead_letter_options =
+      dead_letter[:options]
+      |> build_arguments()
+      |> Keyword.delete(:ttl)
+      |> Keyword.delete(:max_priority)
+    dead_letter = Keyword.put(dead_letter, :options, dead_letter_options)
+
+    options =
+      options
+      |> build_arguments(dead_letter)
+      |> Keyword.delete(:ttl)
+      |> Keyword.delete(:max_priority)
+
+    %{
+      name: name,
+      options: options,
+      dead_letter: dead_letter
+    }
+  end
+
+  defp build_arguments(options, dead_letter \\ []) do
+    create_dead_letter = dead_letter[:create]
+
+    options
+    |> setup_ttl()
+    |> setup_priority()
+    |> setup_dead_letter_exchange(dead_letter, create_dead_letter)
+    |> setup_dead_letter_routing_key(dead_letter, create_dead_letter)
+  end
+
+  defp setup_ttl(options) do
+    case options[:ttl] do
+      nil -> options
+      value ->
+        args = Keyword.get(options, :arguments, [])
+        Keyword.put(options, :arguments, [{"x-expires", :long, value} | args])
+    end
+  end
+
+  defp setup_priority(options) do
+    case options[:max_priority] do
+      nil ->
+        options
+      value ->
+        value = set_max_priority_to_highest_value(value)
+        args = Keyword.get(options, :arguments, [])
+        Keyword.put(options, :arguments, [{"x-max-priority", :long, value} | args])
+    end
+  end
+
+  defp setup_dead_letter_exchange(options, _dead_letter, nil), do: options
+  defp setup_dead_letter_exchange(options, _dead_letter, false), do: options
+  defp setup_dead_letter_exchange(options, dead_letter, true) do
+    args = Keyword.get(options, :arguments, [])
+    Keyword.put(
+      options,
+      :arguments,
+      [{"x-dead-letter-exchange", :longstr, dead_letter[:exchange]} | args])
+  end
+
+  defp setup_dead_letter_routing_key(options, _dead_letter, nil), do: options
+  defp setup_dead_letter_routing_key(options, _dead_letter, false), do: options
+  defp setup_dead_letter_routing_key(options, dead_letter, true) do
+    case dead_letter[:routing_key] != "#" do
+      true ->
+        args = Keyword.get(options, :arguments, [])
+        Keyword.put(
+          options,
+          :arguments,
+          [{"x-dead-letter-routing-key", :longstr, dead_letter[:routing_key]} | args])
+      false ->
+        options
+    end
+  end
 
   defp set_max_priority_to_highest_value(mp)
        when is_integer(mp) and mp > @max_priority do
     255
   end
-
   defp set_max_priority_to_highest_value(mp) when is_integer(mp), do: mp
 end

--- a/test/gen_rmq/consumer/queue_configuration_test.exs
+++ b/test/gen_rmq/consumer/queue_configuration_test.exs
@@ -2,58 +2,304 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
   use ExUnit.Case, async: true
   alias GenRMQ.Consumer.QueueConfiguration
 
-  test "may be built with just a queue name" do
-    qc = QueueConfiguration.new("some_queue_name")
-    assert "some_queue_name" == QueueConfiguration.name(qc)
-  end
-
-  test "durable should default to true" do
-    qc = QueueConfiguration.new("some_queue_name")
-    assert QueueConfiguration.durable(qc)
-  end
-
-  test "may be built with all options" do
+  test "queue setup without arguments returns default configuration" do
     name = "some_queue_name"
-    ttl = 5000
-    durable = false
-    max_priority = 200
 
-    qc =
-      QueueConfiguration.new(
-        name,
-        durable,
-        ttl,
-        max_priority
-      )
+    expected_conf = %{
+      dead_letter: [
+        options: [
+          durable: true
+        ],
+        create: true,
+        name: "#{name}_error",
+        exchange: ".deadletter",
+        routing_key: "#",
+      ],
+      name: name,
+      options: [
+        arguments: [
+          {"x-dead-letter-exchange", :longstr, ".deadletter"}
+        ],
+        durable: true
+      ]
+    }
 
-    assert name == QueueConfiguration.name(qc)
-    assert durable == QueueConfiguration.durable(qc)
-    assert ttl == QueueConfiguration.ttl(qc)
-    assert max_priority == QueueConfiguration.max_priority(qc)
+    qc = QueueConfiguration.setup(name, [])
+
+    assert expected_conf == qc
   end
 
-  test "sets max_priority values that are too large to the max" do
-    qc = QueueConfiguration.new("some_queue_name", max_priority: 500)
-    assert 255 == QueueConfiguration.max_priority(qc)
+  test "queue setup with basic arguments returns correct configuration" do
+    name = "some_queue_name"
+
+    config = [
+      queue: name,
+      exchange: "example_exchange",
+      routing_key: "routing_key.#",
+      prefetch_count: "10",
+      uri: "amqp://guest:guest@localhost:5672"
+    ]
+
+    expected_conf = %{
+      dead_letter: [
+        options: [
+          durable: true
+        ],
+        create: true,
+        name: "#{name}_error",
+        exchange: "#{config[:exchange]}.deadletter",
+        routing_key: "#",
+      ],
+      name: name,
+      options: [
+        arguments: [
+          {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"}
+        ],
+        durable: true
+      ]
+    }
+
+    qc = QueueConfiguration.setup(name, config)
+
+    assert expected_conf == qc
   end
 
-  test "builds empty arguments when neither ttl or max_priority are provided" do
-    qc = QueueConfiguration.new("some_queue_name")
-    assert [] == QueueConfiguration.build_queue_arguments(qc, [])
+  test "queue setup with ttl and priority returns correct configuration" do
+    name = "some_queue_name"
+
+    config = [
+      queue: name,
+      queue_ttl: 300,
+      queue_max_priority: 64,
+      exchange: "example_exchange",
+      routing_key: "routing_key.#",
+      prefetch_count: "10",
+      uri: "amqp://guest:guest@localhost:5672"
+    ]
+
+    expected_conf = %{
+      dead_letter: [
+        options: [
+          arguments: [
+            {"x-max-priority", :long, config[:queue_max_priority]},
+            {"x-expires", :long, config[:queue_ttl]}
+          ],
+          durable: true
+        ],
+        create: true,
+        name: "#{name}_error",
+        exchange: "#{config[:exchange]}.deadletter",
+        routing_key: "#",
+      ],
+      name: name,
+      options: [
+        arguments: [
+          {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"},
+          {"x-max-priority", :long, config[:queue_max_priority]},
+          {"x-expires", :long, config[:queue_ttl]}
+        ],
+        durable: true
+      ]
+    }
+
+    qc = QueueConfiguration.setup(name, config)
+
+    assert expected_conf == qc
   end
 
-  test "builds correct arguments when ttl and max_priority are provided" do
-    ttl = 5000
-    max_priority = 5
+  test "queue setup with queue_options returns correct configuration" do
+    name = "some_queue_name"
 
-    qc =
-      QueueConfiguration.new(
-        "some_queue_name",
-        ttl: ttl,
-        max_priority: max_priority
-      )
+    config = [
+      queue: name,
+      queue_ttl: 300,
+      queue_max_priority: 64,
+      queue_options: [
+        durable: false,
+        auto_delete: true,
+        passive: true,
+        no_wait: true,
+        arguments: [
+          {"x-queue-type", :longstr ,"quorum"},
+          {"x-expires", :long, 42},
+          {"x-max-priority", :long, 1234},
+        ]
+      ],
+      exchange: "example_exchange",
+      routing_key: "routing_key.#",
+      prefetch_count: "10",
+      uri: "amqp://guest:guest@localhost:5672"
+    ]
 
-    assert [{"x-expires", :long, ttl}, {"x-max-priority", :long, max_priority}] ==
-             QueueConfiguration.build_queue_arguments(qc, [])
+    expected_conf = %{
+      dead_letter: [
+        options: [
+          arguments: [
+            {"x-max-priority", :long, 64},
+            {"x-expires", :long, 300},
+          ],
+          durable: true
+        ],
+        create: true,
+        name: "#{name}_error",
+        exchange: "#{config[:exchange]}.deadletter",
+        routing_key: "#",
+      ],
+      name: name,
+      options: [
+        arguments: [
+          {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"},
+          {"x-queue-type", :longstr ,"quorum"},
+          {"x-expires", :long, 42},
+          {"x-max-priority", :long, 1234},
+        ],
+        durable: false,
+        auto_delete: true,
+        passive: true,
+        no_wait: true,
+      ]
+    }
+
+    qc = QueueConfiguration.setup(name, config)
+
+    assert expected_conf == qc
   end
+
+  test "should not create dead letter queue configuration" do
+    name = "some_queue_name"
+
+    config = [
+      deadletter: false,
+    ]
+
+    expected_conf = %{
+      dead_letter: [
+        options: [
+          durable: true
+        ],
+        create: false,
+        name: "#{name}_error",
+        exchange: ".deadletter",
+        routing_key: "#",
+      ],
+      name: name,
+      options: [
+        durable: true
+      ]
+    }
+
+    qc = QueueConfiguration.setup(name, config)
+
+    assert expected_conf == qc
+  end
+
+  test "queue setup with defined dead letter keywords returns correct configuration " do
+    name = "some_queue_name"
+
+    config = [
+      deadletter: true,
+      deadletter_queue: "deadletter",
+      deadletter_exchange: "deadletter_exchange",
+      deadletter_routing_key: "rk",
+    ]
+
+    expected_conf = %{
+      dead_letter: [
+        options: [
+          durable: true
+        ],
+        create: true,
+        name: config[:deadletter_queue],
+        exchange: config[:deadletter_exchange],
+        routing_key: config[:deadletter_routing_key],
+      ],
+      name: name,
+      options: [
+        arguments: [
+          {"x-dead-letter-routing-key", :longstr, config[:deadletter_routing_key]},
+          {"x-dead-letter-exchange", :longstr, config[:deadletter_exchange]}
+        ],
+        durable: true
+      ]
+    }
+
+    qc = QueueConfiguration.setup(name, config)
+
+    assert expected_conf == qc
+  end
+
+  test "queue setup with deal_letter_queue_options returns correct configuration" do
+    name = "some_queue_name"
+
+    config = [
+      queue: name,
+      queue_ttl: 300,
+      queue_max_priority: 64,
+      queue_options: [
+        durable: true,
+        auto_delete: true,
+        passive: true,
+        no_wait: true,
+        arguments: [
+          {"x-queue-type", :longstr ,"quorum"},
+          {"x-expires", :long, 42},
+          {"x-max-priority", :long, 1234},
+        ]
+      ],
+      deadletter_queue_options: [
+        durable: false,
+        auto_delete: true,
+        passive: false,
+        no_wait: false,
+        arguments: [
+          {"x-queue-type", :longstr ,"quorum"},
+          {"x-expires", :long, 42}
+        ]
+      ],
+      deadletter_routing_key: "rk",
+      exchange: "example_exchange",
+      routing_key: "routing_key.#",
+      prefetch_count: "10",
+      uri: "amqp://guest:guest@localhost:5672"
+    ]
+
+    expected_conf = %{
+      dead_letter: [
+        options: [
+          arguments: [
+            {"x-max-priority", :long, 64},
+            {"x-queue-type", :longstr ,"quorum"},
+            {"x-expires", :long, 42},
+          ],
+          durable: false,
+          auto_delete: true,
+          passive: false,
+          no_wait: false,
+        ],
+        create: true,
+        name: "#{name}_error",
+        exchange: "#{config[:exchange]}.deadletter",
+        routing_key: config[:deadletter_routing_key],
+      ],
+      name: name,
+      options: [
+        arguments: [
+          {"x-dead-letter-routing-key", :longstr, config[:deadletter_routing_key]},
+          {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"},
+          {"x-queue-type", :longstr ,"quorum"},
+          {"x-expires", :long, 42},
+          {"x-max-priority", :long, 1234},
+        ],
+        durable: true,
+        auto_delete: true,
+        passive: true,
+        no_wait: true,
+      ]
+    }
+
+    qc = QueueConfiguration.setup(name, config)
+
+    assert expected_conf == qc
+  end
+
 end

--- a/test/gen_rmq/consumer/queue_configuration_test.exs
+++ b/test/gen_rmq/consumer/queue_configuration_test.exs
@@ -120,7 +120,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         passive: true,
         no_wait: true,
         arguments: [
-          {"x-queue-type", :longstr ,"quorum"},
+          {"x-queue-type", :longstr, "quorum"},
           {"x-expires", :long, 42},
           {"x-max-priority", :long, 1234},
         ]
@@ -149,7 +149,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
       options: [
         arguments: [
           {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"},
-          {"x-queue-type", :longstr ,"quorum"},
+          {"x-queue-type", :longstr, "quorum"},
           {"x-expires", :long, 42},
           {"x-max-priority", :long, 1234},
         ],
@@ -241,7 +241,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         passive: true,
         no_wait: true,
         arguments: [
-          {"x-queue-type", :longstr ,"quorum"},
+          {"x-queue-type", :longstr, "quorum"},
           {"x-expires", :long, 42},
           {"x-max-priority", :long, 1234},
         ]
@@ -252,7 +252,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         passive: false,
         no_wait: false,
         arguments: [
-          {"x-queue-type", :longstr ,"quorum"},
+          {"x-queue-type", :longstr, "quorum"},
           {"x-expires", :long, 42}
         ]
       ],
@@ -268,7 +268,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         options: [
           arguments: [
             {"x-max-priority", :long, 64},
-            {"x-queue-type", :longstr ,"quorum"},
+            {"x-queue-type", :longstr, "quorum"},
             {"x-expires", :long, 42},
           ],
           durable: false,
@@ -286,7 +286,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         arguments: [
           {"x-dead-letter-routing-key", :longstr, config[:deadletter_routing_key]},
           {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"},
-          {"x-queue-type", :longstr ,"quorum"},
+          {"x-queue-type", :longstr, "quorum"},
           {"x-expires", :long, 42},
           {"x-max-priority", :long, 1234},
         ],

--- a/test/gen_rmq_consumer_test.exs
+++ b/test/gen_rmq_consumer_test.exs
@@ -7,6 +7,7 @@ defmodule GenRMQ.ConsumerTest do
 
   alias GenRMQ.Consumer
   alias TestConsumer.Default
+  alias TestConsumer.WithQueueOptions
   alias TestConsumer.WithCustomDeadletter
   alias TestConsumer.WithoutConcurrency
   alias TestConsumer.WithoutDeadletter
@@ -144,6 +145,27 @@ defmodule GenRMQ.ConsumerTest do
         assert queue_count(context[:rabbit_conn], state.config[:queue][:dead_letter][:name]) == {:error, :not_found}
       end)
     end
+  end
+
+  describe "TestConsumer.WithQueueOptions" do
+    setup do
+      Agent.start_link(fn -> MapSet.new() end, name: WithQueueOptions)
+      with_test_consumer(WithQueueOptions)
+    end
+
+    receive_message_test(WithQueueOptions)
+
+    reject_message_test()
+
+    reconnect_after_connection_failure_test(WithQueueOptions)
+
+    terminate_after_queue_deletion_test()
+
+    exit_signal_after_queue_deletion_test()
+
+    close_connection_and_channels_after_deletion_test()
+
+    close_connection_and_channels_after_shutdown_test()
   end
 
   describe "TestConsumer.WithCustomDeadletter" do

--- a/test/gen_rmq_consumer_test.exs
+++ b/test/gen_rmq_consumer_test.exs
@@ -140,8 +140,8 @@ defmodule GenRMQ.ConsumerTest do
 
       Assert.repeatedly(fn ->
         assert Process.alive?(consumer_pid) == true
-        assert queue_count(context[:rabbit_conn], "#{state.config[:queue].name}") == {:ok, 0}
-        assert queue_count(context[:rabbit_conn], "#{state.config[:queue].name}_error") == {:error, :not_found}
+        assert queue_count(context[:rabbit_conn], state[:config][:queue].name) == {:ok, 0}
+        assert queue_count(context[:rabbit_conn], state.config[:queue][:dead_letter][:name]) == {:error, :not_found}
       end)
     end
   end
@@ -153,7 +153,7 @@ defmodule GenRMQ.ConsumerTest do
 
     test "should deadletter a message to a custom queue", %{consumer: consumer_pid, state: state} = context do
       message = %{"msg" => "some message"}
-      dl_queue = state[:config][:deadletter_queue]
+      dl_queue = state.config[:queue][:dead_letter][:name]
 
       publish_message(context[:rabbit_conn], context[:exchange], Jason.encode!(message))
 
@@ -292,7 +292,7 @@ defmodule GenRMQ.ConsumerTest do
       publish_message(context[:rabbit_conn], context[:exchange], Jason.encode!(message), "routing_key_1")
 
       Assert.repeatedly(fn ->
-        assert queue_count(context[:rabbit_conn], "#{state.config[:queue].name}_error") == {:ok, 1}
+        assert queue_count(context[:rabbit_conn], state.config[:queue][:dead_letter][:name]) == {:ok, 1}
       end)
     end
 

--- a/test/support/consumer_shared_tests.ex
+++ b/test/support/consumer_shared_tests.ex
@@ -25,7 +25,7 @@ defmodule ConsumerSharedTests do
         publish_message(context[:rabbit_conn], context[:exchange], Jason.encode!(message))
 
         GenRMQ.Test.Assert.repeatedly(fn ->
-          assert queue_count(context[:rabbit_conn], "#{state.config[:queue].name}_error") == {:ok, 1}
+          assert queue_count(context[:rabbit_conn], state.config[:queue][:dead_letter][:name]) == {:ok, 1}
         end)
       end
     end
@@ -61,7 +61,7 @@ defmodule ConsumerSharedTests do
   defmacro exit_signal_after_queue_deletion_test do
     quote do
       test "should send exit signal after queue deletion", %{consumer: consumer_pid, state: state} do
-        AMQP.Queue.delete(state.out, state[:config][:queue].name)
+        AMQP.Queue.delete(state.out, state.config[:queue].name)
 
         assert_receive({:EXIT, ^consumer_pid, :cancelled})
       end
@@ -71,7 +71,7 @@ defmodule ConsumerSharedTests do
   defmacro close_connection_and_channels_after_deletion_test do
     quote do
       test "should close connection and channels after queue deletion", %{state: state} do
-        AMQP.Queue.delete(state.out, state[:config][:queue].name)
+        AMQP.Queue.delete(state.out, state.config[:queue].name)
 
         GenRMQ.Test.Assert.repeatedly(fn ->
           assert Process.alive?(state.conn.pid) == false


### PR DESCRIPTION
## Description

Refactored queue configuration

There are now two new keys, queue_options and deadletter_queue_options, on init. These are queue options as declared in [AMQP.Queue.declare/3](https://hexdocs.pm/amqp/AMQP.Queue.html#declare/3). Both are optional.

All existing options like queue_ttl will still work but these new queue_options will be used if they are present.

This fixes issue #147 by allowing user to pass x-arguments to queue declare.

## Examples
```elixir
def init() do
    [
      connection: "amqp://guest:guest@localhost:5672"
      queue: "example_queue",
      queue_options: [
        durable: true,
        arguments: [
          {"x-queue-type", :longstr ,"quorum"},
        ]
      deadletter_queue_options: [
        durable: false
        arguments: [
          {"x-expires :long, 10000},
        ]
      ],
      exchange: "example_exchange",
      routing_key: "routing_key.#",
      prefetch_count: "10",
    ]
end
```
## Implementation

QueueConfiguration module and setup_consumer function are completely rewritten. Other changes are mainly small renames in tests. Maintaining backwards compatibility caused some extra code and
there are few lines that aren't that pretty but in overall, it should be readable code.

## Checklist
- [x] I have added unit tests to cover my changes.
- [x] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [x] I have updated the documentation accordingly
