### PR TITLE
Add Link Checker (as GitHub Action)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+# GitHub Action: https://github.com/marketplace/actions/link-checker
+# Link Checker: https://github.com/raviqqe/liche
+name: Link Check
+
+on: push
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Link Checker
+      id: lc
+      uses: peter-evans/link-checker@v1
+      with:
+        args: -v -r .
+    - name: Fail if there were link errors
+      run: exit ${{ steps.lc.outputs.exit_code }}

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The maintainers are the ones that create new releases of gen_rmq.
 * Joel ([@vorce](https://github.com/vorce))
 * Sebastian ([@spier](https://github.com/spier))
 
-**Trusted Committers** are members of our community who we have explicitly added to our GitHub repository. 
+**Trusted Committers** are members of our community who we have explicitly added to our GitHub repository.
 
 Trusted Committers have elevated rights, allowing them to send in changes directly to branches and to approve Pull Requests.
 
@@ -163,7 +163,7 @@ The [MIT License](LICENSE).
 
 Copyright (c) 2018 - 2020 Meltwater Inc. [underthehood.meltwater.com][underthehood]
 
-[behaviours]: https://hexdocs.pm/elixir/behaviours.html
+[behaviours]: https://elixir-lang.org/getting-started/typespecs-and-behaviours.html#behaviours
 [amqp]: https://github.com/pma/amqp
 [rabbit_case_example]: https://github.com/meltwater/gen_rmq/blob/master/test/gen_rmq_publisher_test.exs
 [migrating_to_100]: https://github.com/meltwater/gen_rmq/wiki/Migrations#0---100


### PR DESCRIPTION
Adds a link checker to prevent broken links e.g. in `.md` files.
The link check is done in a GitHub Action.

When trying this locally I found one broken link already :)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
