### PR TITLE
Ensure we are using absolute links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you were a very early adopter of gen_rmq (before `v1.0.0`), please check [how
 ## Examples
 
 More thorough examples for using `GenRMQ.Consumer`, `GenRMQ.Publisher`, and `GenRMQ.Processor`
-can be found under [documentation](./documentation/examples).
+can be found under [documentation][examples].
 
 ### Consumer
 
@@ -110,17 +110,17 @@ GenRMQ.Publisher.publish(Publisher, Jason.encode!(%{msg: "msg"}))
 
 ### Guides
 
-1. [Basic consumer setup](./documentation/guides/consumer/basic_setup.md)
-2. [Consumer with custom deadletter configuration](./documentation/guides/consumer/with_custom_deadletter_configuration.md)
-3. [Consumer with custom exchange type](./documentation/guides/consumer/with_custom_exchange_type.md)
-4. [Consumer with custom queue configuration](./documentation/guides/consumer/with_custom_queue_configuration.md)
-5. [Consumer without deadletter configuration](./documentation/guides/consumer/without_deadletter_configuration.md)
-6. [Consumer with quorum queues](./documentation/guides/consumer/with_quorum_queue_type.md)
+1. [Basic consumer setup][guide_consumer_basic_setup]
+2. [Consumer with custom deadletter configuration][guide_consumer_with_custom_deadletter_configuration]
+3. [Consumer with custom exchange type][guide_consumer_with_custom_exchange_type]
+4. [Consumer with custom queue configuration][guide_consumer_with_custom_queue_configuration]
+5. [Consumer without deadletter configuration][without_deadletter_configuration]
+6. [Consumer with quorum queues][with_quorum_queue_type]
 
 ### Metrics
 
-1. [Consumer Telemetry events](./documentation/guides/consumer/telemetry_events.md)
-2. [Publisher Telemetry events](./documentation/guides/publisher/telemetry_events.md)
+1. [Consumer Telemetry events][consumer_telemetry_events]
+2. [Publisher Telemetry events][publisher_telemetry_events]
 
 ## Running Tests
 
@@ -153,9 +153,9 @@ The maintainers are the ones that create new releases of gen_rmq.
 
 Trusted Committers have elevated rights, allowing them to send in changes directly to branches and to approve Pull Requests.
 
-For details see [TRUSTED-COMMITTERS.md](TRUSTED-COMMITTERS.md).
+For details see [TRUSTED-COMMITTERS.md][trusted_commiters].
 
-*Note:* Maintainers as well as Trusted Committers are listed in [.github/CODEOWNERS](.github/CODEOWNERS), in order to automatically assign PR reviews to them.
+*Note:* Maintainers as well as Trusted Committers are listed in [.github/CODEOWNERS][code_owners] in order to automatically assign PR reviews to them.
 
 ## License
 
@@ -172,7 +172,22 @@ Copyright (c) 2018 - 2020 Meltwater Inc. [underthehood.meltwater.com][undertheho
 [gen_rmq_issues]: https://github.com/meltwater/gen_rmq/issues
 [priority_queues]: https://www.rabbitmq.com/priority.html
 [underthehood]: http://underthehood.meltwater.com/
-[example_consumer]: ./documentation/examples/consumer.ex
-[example_publisher]: ./documentation/examples/publisher.ex
-[example_processor]: ./documentation/examples/processor.ex
+
+[examples]: https://github.com/meltwater/gen_rmq/blob/master/documentation/examples
+[example_consumer]: https://github.com/meltwater/gen_rmq/blob/master/documentation/examples/consumer.ex
+[example_publisher]: https://github.com/meltwater/gen_rmq/blob/master/documentation/examples/publisher.ex
+[example_processor]: https://github.com/meltwater/gen_rmq/blob/master/documentation/examples/processor.ex
 [example_rabbit_case]: https://github.com/meltwater/gen_rmq/blob/master/test/gen_rmq_publisher_test.exs
+
+[guide_consumer_basic_setup]: https://github.com/meltwater/gen_rmq/blob/master/documentation/guides/consumer/basic_setup.md
+[guide_consumer_with_custom_deadletter_configuration]: https://github.com/meltwater/gen_rmq/blob/master/documentation/guides/consumer/with_custom_deadletter_configuration.md
+[guide_consumer_with_custom_exchange_type]: https://github.com/meltwater/gen_rmq/blob/master/documentation/guides/consumer/with_custom_exchange_type.md
+[guide_consumer_with_custom_queue_configuration]: https://github.com/meltwater/gen_rmq/blob/master/documentation/guides/consumer/with_custom_queue_configuration.md
+[without_deadletter_configuration]: https://github.com/meltwater/gen_rmq/blob/master/documentation/guides/consumer/without_deadletter_configuration.md
+[with_quorum_queue_type]: https://github.com/meltwater/gen_rmq/blob/master/documentation/guides/consumer/with_quorum_queue_type.md
+
+[consumer_telemetry_events]: https://github.com/meltwater/gen_rmq/blob/master/documentation/guides/consumer/telemetry_events.md
+[publisher_telemetry_events]: https://github.com/meltwater/gen_rmq/blob/master/documentation/guides/publisher/telemetry_events.md
+
+[trusted_commiters]: https://github.com/meltwater/gen_rmq/blob/master/TRUSTED-COMMITTERS.md
+[code_owners]: https://github.com/meltwater/gen_rmq/blob/master/.github/CODEOWNERS

--- a/README.md
+++ b/README.md
@@ -104,23 +104,23 @@ GenRMQ.Publisher.publish(Publisher, Jason.encode!(%{msg: "msg"}))
 
 ### Examples
 
-1. [Consumer][example_consumer]
-2. [Publisher][example_publisher]
-3. [Processor][example_processor]
+- [Consumer][example_consumer]
+- [Publisher][example_publisher]
+- [Processor][example_processor]
 
 ### Guides
 
-1. [Basic consumer setup][guide_consumer_basic_setup]
-2. [Consumer with custom deadletter configuration][guide_consumer_with_custom_deadletter_configuration]
-3. [Consumer with custom exchange type][guide_consumer_with_custom_exchange_type]
-4. [Consumer with custom queue configuration][guide_consumer_with_custom_queue_configuration]
-5. [Consumer without deadletter configuration][without_deadletter_configuration]
-6. [Consumer with quorum queues][with_quorum_queue_type]
+- [Basic consumer setup][guide_consumer_basic_setup]
+- [Consumer with custom deadletter configuration][guide_consumer_with_custom_deadletter_configuration]
+- [Consumer with custom exchange type][guide_consumer_with_custom_exchange_type]
+- [Consumer with custom queue configuration][guide_consumer_with_custom_queue_configuration]
+- [Consumer without deadletter configuration][without_deadletter_configuration]
+- [Consumer with quorum queues][with_quorum_queue_type]
 
 ### Metrics
 
-1. [Consumer Telemetry events][consumer_telemetry_events]
-2. [Publisher Telemetry events][publisher_telemetry_events]
+- [Consumer Telemetry events][consumer_telemetry_events]
+- [Publisher Telemetry events][publisher_telemetry_events]
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For details see [TRUSTED-COMMITTERS.md][trusted_commiters].
 
 ## License
 
-The [MIT License](LICENSE).
+The [MIT License][license].
 
 Copyright (c) 2018 - 2020 Meltwater Inc. [underthehood.meltwater.com][underthehood]
 
@@ -191,3 +191,4 @@ Copyright (c) 2018 - 2020 Meltwater Inc. [underthehood.meltwater.com][undertheho
 
 [trusted_commiters]: https://github.com/meltwater/gen_rmq/blob/master/TRUSTED-COMMITTERS.md
 [code_owners]: https://github.com/meltwater/gen_rmq/blob/master/.github/CODEOWNERS
+[license]: https://github.com/meltwater/gen_rmq/blob/master/LICENSE

--- a/documentation/guides/consumer/with_custom_exchange_type.md
+++ b/documentation/guides/consumer/with_custom_exchange_type.md
@@ -1,5 +1,5 @@
-Consumer with custom exchange
-=============================
+Consumer with custom exchange type
+==================================
 
 By default consumer creates `topic` exchanges. This can be modified by
 specyfying exchange type: `exchange: {:fanout, "custom_exchange"}`.

--- a/documentation/guides/consumer/with_custom_queue_configuration.md
+++ b/documentation/guides/consumer/with_custom_queue_configuration.md
@@ -1,5 +1,5 @@
-Consumer with custom queue options
-==================================
+Consumer with custom queue configuration
+========================================
 
 `queue_options` - Queue options as declared in
 [AMQP.Queue.declare/3](https://hexdocs.pm/amqp/AMQP.Queue.html#declare/3).

--- a/documentation/guides/consumer/with_quorum_queue_type.md
+++ b/documentation/guides/consumer/with_quorum_queue_type.md
@@ -1,5 +1,5 @@
-Consumer with quorum queues
-===========================
+Consumer with quorum queue type
+===============================
 
 You can change from `classic` to a `quorum` queue type by specyfing corresponding
 queue arguments. Read more about quorum queues [here](https://www.rabbitmq.com/quorum-queues.html).

--- a/documentation/guides/consumer/without_deadletter_configuration.md
+++ b/documentation/guides/consumer/without_deadletter_configuration.md
@@ -1,5 +1,5 @@
-Consumer without deadletter setup
-=================================
+Consumer without deadletter configuration
+=========================================
 
 # Example
 


### PR DESCRIPTION
* Otherwise those links will be broken at [https://hexdocs.pm/gen_rmq/readme.html](https://hexdocs.pm/gen_rmq/readme.html), since `README.md` becomes a home page and `documentation` folder is not hosted on hex.pm.

* Update guide titles for consistency

* Replace documentation numbered list with a bulleted list

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
