### PR TITLE
Rename gen_rmq to GenRMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ end
 
 ## Migrations
 
-If you were a very early adopter of gen_rmq (before `v1.0.0`), please check [how to migrate to gen_rmq `1.0.0`][migrating_to_100].
+If you were a very early adopter of GenRMQ (before `v1.0.0`), please check [how to migrate to gen_rmq `1.0.0`][migrating_to_100].
 
 ## Examples
 
@@ -134,7 +134,7 @@ $ make test
 
 We happily accept contributions as [GitHub PRs][github_prs] or bug reports, comments/suggestions or usage questions by creating a [GitHub issue][gen_rmq_issues].
 
-Are you using `gen_rmq` in production? Please let us know, we are curious to learn about your experiences!
+Are you using GenRMQ in Production? Please let us know, we are curious to learn about your experiences!
 
 ## Maintainers
 
@@ -142,20 +142,16 @@ Are you using `gen_rmq` in production? Please let us know, we are curious to lea
 
 The maintainers are responsible for the general project oversight, and empowering further trusted committers (see below).
 
-The maintainers are the ones that create new releases of gen_rmq.
+The maintainers are the ones that create new releases of GenRMQ.
 
 ## Trusted Committers
 
 * Joel ([@vorce](https://github.com/vorce))
 * Sebastian ([@spier](https://github.com/spier))
 
-**Trusted Committers** are members of our community who we have explicitly added to our GitHub repository.
+Trusted Committers are members of our community who we have explicitly added to our GitHub repository. Trusted Committers have elevated rights, allowing them to send in changes directly to branches and to approve Pull Requests. For details see [TRUSTED-COMMITTERS.md][trusted_commiters].
 
-Trusted Committers have elevated rights, allowing them to send in changes directly to branches and to approve Pull Requests.
-
-For details see [TRUSTED-COMMITTERS.md][trusted_commiters].
-
-*Note:* Maintainers as well as Trusted Committers are listed in [.github/CODEOWNERS][code_owners] in order to automatically assign PR reviews to them.
+*Note:* Maintainers and Trusted Committers are listed in [.github/CODEOWNERS][code_owners] in order to automatically assign PR reviews to them.
 
 ## License
 

--- a/TRUSTED-COMMITTERS.md
+++ b/TRUSTED-COMMITTERS.md
@@ -7,19 +7,19 @@ We ask that TC's open Pull-Request when making changes, to make these changes tr
 ## What you get as a Trusted Committer:
 
 - **WRITE** access to this repository (no need to maintain your own fork)
-- More immediate impact on the roadmap and feature development of gen_rmq
-- Fame and glory in the gen_rmq community :)
+- More immediate impact on the roadmap and feature development of GenRMQ
+- Fame and glory in the GenRMQ community :)
 
 ## What we expect from a Trusted Committer:
 
-- Help us to drive the conversations in GitHub Issues (e.g. provide feedback to other user of gen_rmq or answer their questions)
+- Help us to drive the conversations in GitHub Issues (e.g. provide feedback to other user of GenRMQ or answer their questions)
 - Review pull requests (e.g. by helping the author of the PR understand what needs to be done in order to get the PR into a mergeable shape)
-- Be a role model for for our [Code of Conduct](CODE_OF_CONDUCT.md)
+- Be a role model for our [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## Adding Trusted Committers 
 
 It is our ambition to empower as many trusted Trusted Committers as possible.
 
-When a GitHub user has made a couple of contributions to gen_rmq, we will contact them and ask them if they want to support the development of gen_rmq by becoming a Trusted Committer. We will use a GitHub issue on this repo to do that.
+When a GitHub user has made a couple of contributions to GenRMQ, we will contact them and ask them if they want to support the development of GenRMQ by becoming a Trusted Committer. We will use a GitHub issue on this repo to do that.
 
 [collaborators]: https://help.github.com/en/articles/adding-outside-collaborators-to-repositories-in-your-organization


### PR DESCRIPTION
In the README changes that I made previously, I had wrongly used the spelling `gen_rmq` in a couple of places.

This PR replaces `gen_rmq` with `GenRMQ` where that makes sense.

Minor changes:
- reformat the TC section in README.
- fix one typo.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [x] I have updated the documentation accordingly
