### PR TITLE
Fix options parsing

### DIFF
--- a/lib/gen_rmq/consumer/queue_configuration.ex
+++ b/lib/gen_rmq/consumer/queue_configuration.ex
@@ -56,9 +56,11 @@ defmodule GenRMQ.Consumer.QueueConfiguration do
     # This is done in order to be backwards compatible.
     # If one day those two keywords are removed from the
     # init, then this function can be removed as well.
+    queue_option_arguments = Keyword.get(option_list, :arguments, [])
+
     word_list
-    |> remove_keyword(option_list[:arguments], %{name: "x-expires", word: :ttl})
-    |> remove_keyword(option_list[:arguments], %{name: "x-max-priority", word: :max_priority})
+    |> remove_keyword(queue_option_arguments, %{name: "x-expires", word: :ttl})
+    |> remove_keyword(queue_option_arguments, %{name: "x-max-priority", word: :max_priority})
     |> Keyword.merge(option_list)
   end
 

--- a/lib/gen_rmq/consumer/queue_configuration.ex
+++ b/lib/gen_rmq/consumer/queue_configuration.ex
@@ -64,6 +64,8 @@ defmodule GenRMQ.Consumer.QueueConfiguration do
     |> Keyword.merge(option_list)
   end
 
+  defp remove_keyword(word_list, [], _argument), do: word_list
+
   defp remove_keyword(word_list, option_arguments, argument) do
     case Enum.find(option_arguments, fn arg -> elem(arg, 0) == argument.name end) do
       nil -> word_list

--- a/test/gen_rmq_consumer_test.exs
+++ b/test/gen_rmq_consumer_test.exs
@@ -18,6 +18,7 @@ defmodule GenRMQ.ConsumerTest do
   alias TestConsumer.WithFanoutExchange
   alias TestConsumer.WithMultiBindingExchange
   alias TestConsumer.RedeclaringExistingExchange
+  alias TestConsumer.WithQueueOptionsWithoutArguments
 
   @connection "amqp://guest:guest@localhost:5672"
 
@@ -328,6 +329,25 @@ defmodule GenRMQ.ConsumerTest do
         assert Agent.get(WithMultiBindingExchange, fn set -> message in set end) == true
       end)
     end
+
+    terminate_after_queue_deletion_test()
+
+    exit_signal_after_queue_deletion_test()
+
+    close_connection_and_channels_after_deletion_test()
+
+    close_connection_and_channels_after_shutdown_test()
+  end
+
+  describe "TestConsumer.WithQueueOptionsWithoutArguments" do
+    setup do
+      Agent.start_link(fn -> MapSet.new() end, name: WithQueueOptionsWithoutArguments)
+      with_test_consumer(WithQueueOptionsWithoutArguments)
+    end
+
+    receive_message_test(WithQueueOptionsWithoutArguments)
+
+    reconnect_after_connection_failure_test(WithQueueOptionsWithoutArguments)
 
     terminate_after_queue_deletion_test()
 

--- a/test/support/test_consumers.ex
+++ b/test/support/test_consumers.ex
@@ -346,4 +346,35 @@ defmodule TestConsumer do
 
     def handle_message(_), do: :ok
   end
+
+  defmodule WithQueueOptionsWithoutArguments do
+    @moduledoc false
+    @behaviour GenRMQ.Consumer
+
+    def init() do
+      [
+        queue: "gen_rmq_in_queue_options_no_args",
+        queue_options: [durable: true],
+        exchange: {:topic, "gen_rmq_in_exchange_queue_options_no_args"},
+        routing_key: "#",
+        prefetch_count: "10",
+        connection: "amqp://guest:guest@localhost:5672",
+        deadletter: false,
+      ]
+    end
+
+    def consumer_tag() do
+      "TestConsumer.WithQueueOptionsWithoutArguments"
+    end
+
+    def handle_message(%GenRMQ.Message{payload: "\"reject\""} = message) do
+      GenRMQ.Consumer.reject(message)
+    end
+
+    def handle_message(message) do
+      payload = Jason.decode!(message.payload)
+      Agent.update(__MODULE__, &MapSet.put(&1, payload))
+      GenRMQ.Consumer.ack(message)
+    end
+  end
 end


### PR DESCRIPTION
**Problem:**
Currently queue options parsing fails (https://github.com/meltwater/gen_rmq/issues/177) if `queue_options` is specified without arguments list:
~~~iex
queue_options: [durable: true]
~~~

**Solution:**
Expect non-existing arguments list in queue options configuration.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
