### PR TITLE
Custom deadletter exchange type

### DIFF
--- a/lib/gen_rmq/consumer/queue_configuration.ex
+++ b/lib/gen_rmq/consumer/queue_configuration.ex
@@ -140,7 +140,7 @@ defmodule GenRMQ.Consumer.QueueConfiguration do
     Keyword.put(
       options,
       :arguments,
-      [{"x-dead-letter-exchange", :longstr, dead_letter[:exchange]} | args]
+      [{"x-dead-letter-exchange", :longstr, GenRMQ.Binding.exchange_name(dead_letter[:exchange])} | args]
     )
   end
 

--- a/test/support/test_consumers.ex
+++ b/test/support/test_consumers.ex
@@ -248,6 +248,37 @@ defmodule TestConsumer do
     end
   end
 
+  defmodule WithCustomDeadletterExchangeType do
+    @moduledoc false
+    @behaviour GenRMQ.Consumer
+
+    def init() do
+      [
+        queue: "gen_rmq_in_queue_custom_fanout_deadletter",
+        exchange: "gen_rmq_in_exchange_custom_deadletter",
+        routing_key: "#",
+        prefetch_count: "10",
+        connection: "amqp://guest:guest@localhost:5672",
+        queue_ttl: 1_000,
+        deadletter_queue: "dl_queue",
+        deadletter_exchange: {:fanout, "dl_fanout_exchange"},
+        deadletter_routing_key: "dl_routing_key"
+      ]
+    end
+
+    def consumer_tag() do
+      "TestConsumer.WithCustomDeadletterExchangeType"
+    end
+
+    def handle_message(message) do
+      GenRMQ.Consumer.reject(message)
+    end
+
+    def handle_error(message, _reason) do
+      GenRMQ.Consumer.reject(message)
+    end
+  end
+
   defmodule WithPriority do
     @moduledoc false
     @behaviour GenRMQ.Consumer


### PR DESCRIPTION
This pull request will allow deadletter_exchange to have type instead of just a string.

## Description
When I want to use a custom dead letter exchange with another type than the default. This code bellow will raise an error.

```elixir
[
      queue: @app_queue,
      exchange: {:direct, @app_exchange},
      routing_key: @app_routing_key,
      prefetch_count: "10",
      connection: connection,
      deadletter_exchange: {:fanout, @custom_deadletter_exchange},
      deadletter_queue: @queue_error,
      deadletter_routing_key: @queue_error
]
```
```
Terminating consumer, unexpected reason: {:shutdown, {:gen_server, :call, [#PID<0.1145.0>, {:call, {:"queue.declare", 0, "app_queue", false, true, false, false, false, [{"x-dead-letter-routing-key", :longstr, "app_routing_key"}, {"x-dead-letter-exchange", :longstr, {:fanout, "custom_deadletter_exchange"}}]}, :none, #PID<0.1111.0>}, 60000]}}
```
