### PR TITLE
Fixing a typo in the docs

### DIFF
--- a/documentation/guides/consumer/with_quorum_queue_type.md
+++ b/documentation/guides/consumer/with_quorum_queue_type.md
@@ -1,7 +1,7 @@
 Consumer with quorum queue type
 ===============================
 
-You can change from `classic` to a `quorum` queue type by specyfing corresponding
+You can change from `classic` to a `quorum` queue type by specifying corresponding
 queue arguments. Read more about quorum queues [here](https://www.rabbitmq.com/quorum-queues.html).
 
 # Example


### PR DESCRIPTION
I checked that `specyfing` had not been used in other docs as well.
Looks like this is the only instance that needs to be fixed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
