### PR TITLE
Fix for issue #214

### DIFF
--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -284,7 +284,7 @@ defmodule GenRMQ.Consumer do
   `message` - `GenRMQ.Message` struct
   """
   @spec ack(message :: %GenRMQ.Message{}) :: :ok
-  def ack(%Message{state: %{in: channel}, attributes: %{delivery_tag: tag}} = message) do
+  def ack(%Message{channel: channel, attributes: %{delivery_tag: tag}} = message) do
     Telemetry.emit_message_ack_event(message)
 
     Basic.ack(channel, tag)
@@ -298,7 +298,7 @@ defmodule GenRMQ.Consumer do
   `requeue` - indicates if message should be requeued
   """
   @spec reject(message :: %GenRMQ.Message{}, requeue :: boolean) :: :ok
-  def reject(%Message{state: %{in: channel}, attributes: %{delivery_tag: tag}} = message, requeue \\ false) do
+  def reject(%Message{channel: channel, attributes: %{delivery_tag: tag}} = message, requeue \\ false) do
     Telemetry.emit_message_reject_event(message, requeue)
 
     Basic.reject(channel, tag, requeue: requeue)
@@ -440,7 +440,7 @@ defmodule GenRMQ.Consumer do
       Logger.debug("[#{module}]: Redelivered payload for message. Tag: #{tag}, payload: #{payload}")
     end
 
-    message = Message.create(attributes, payload, state)
+    message = Message.create(attributes, payload, state.in)
 
     updated_state =
       case handle_message(message, state) do

--- a/lib/message.ex
+++ b/lib/message.ex
@@ -5,18 +5,32 @@ defmodule GenRMQ.Message do
   Defines:
   * `:attributes` - message attributes
   * `:payload` - message raw payload
-  * `:state` - consumer state
+  * `:channel` - the channel that the message came in from
   """
 
-  @enforce_keys [:attributes, :payload, :state]
-  defstruct [:attributes, :payload, :state]
+  @enforce_keys [:attributes, :payload, :channel]
+  defstruct [:attributes, :payload, :channel]
 
   @doc false
-  def create(attributes, payload, state) do
+  def create(attributes, payload, channel) do
     %__MODULE__{
       attributes: attributes,
       payload: payload,
-      state: state
+      channel: channel
     }
+  end
+end
+
+defimpl Inspect, for: GenRMQ.Message do
+  import Inspect.Algebra
+
+  def inspect(message_struct, opts) do
+    inspect_fields =
+      message_struct
+      |> Map.delete(:channel)
+      |> Map.delete(:__struct__)
+      |> Map.to_list()
+
+    concat(["#GenRMQ.Message<", to_doc(inspect_fields, opts), ">"])
   end
 end

--- a/test/support/test_consumers.ex
+++ b/test/support/test_consumers.ex
@@ -569,8 +569,8 @@ defmodule TestConsumer do
         routing_key: "#",
         prefetch_count: "10",
         connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000,
-        handle_message_timeout: 250
+        queue_ttl: 5_000,
+        handle_message_timeout: 500
       ]
     end
 


### PR DESCRIPTION
This PR should fix issue #214. In short the problem was that the GenServer state contains the currently running TaskSupervisor processes in order to deal with them if they exit normally, timeout, or error. With each subsequent concurrent task, each task will get a copy of the entire GenServer's state (given that this is a field in the Message struct). This will cause the state map going to each task to recursively balloon in size and with each additional task started, the time it takes to perform the memory copy slows everything down to a halt. In other words, with each new task, the GenServer state gets larger (which is fine), but the problem is that each task contains a copy of the state which is recursively duplicated in the state field (which is why the output grows larger and larger on STDOUT in the repro repo that @vorce put together).

This introduces a breaking change which we should probably discuss prior to merging. While before the entire GenServer state was attached to the message struct, the only thing that is copied from the state now is the channel (given that this is needed during the ACK/reject). I would personally argue that this is a good change, given that we were leaking internal implementation details from the GenServer to library consumers and that limited our ability to refactor given that people may be leaning on internally facing structures. But that is just a personal feeling :P.

A test has been added to ensure that with the new approach large numbers of messages concurrently being processed do not cause any issues.
