### PR TITLE
Remove deprecated config options

### DIFF
--- a/documentation/examples/consumer_options.ex
+++ b/documentation/examples/consumer_options.ex
@@ -49,7 +49,7 @@ defmodule ExampleConsumerOptions do
       exchange: "example_exchange",
       routing_key: "routing_key.#",
       prefetch_count: "10",
-      uri: "amqp://guest:guest@localhost:5672",
+      connection: "amqp://guest:guest@localhost:5672",
       deadletter_queue_options: [
         durable: true,
         arguments: [

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -47,26 +47,8 @@ defmodule GenRMQ.Consumer do
 
   ### Optional:
 
-  `uri` - RabbitMQ uri. Deprecated. Please use `connection`.
-
   `queue_options` - queue options as declared in
   [AMQP.Queue.declare/3](https://hexdocs.pm/amqp/AMQP.Queue.html#declare/3).
-
-  If argument 'x-expires' is given to arguments, then it will be used instead
-  of `queue_ttl`.
-
-  If argument 'x-max-priority' is given to arguments, then it will be used
-  instead of `queue_max_priority`.
-
-  `queue_ttl` - controls for how long a queue can be unused before it is
-  automatically deleted. Unused means the queue has no consumers,
-  the queue has not been redeclared, and basic.get has not been invoked
-  for a duration of at least the expiration period
-
-  `queue_max_priority` - defines if a declared queue should be a priority queue.
-  Should be set to a value from `1..255` range. If it is greater than `255`, queue
-  max priority will be set to `255`. Values between `1` and `10` are
-  [recommended](https://www.rabbitmq.com/priority.html#resource-usage).
 
   `concurrency` - defines if `handle_message` callback is called
   in separate process using [supervised task](https://hexdocs.pm/elixir/Task.Supervisor.html).
@@ -96,10 +78,6 @@ defmodule GenRMQ.Consumer do
 
   `deadletter_queue_options` - queue options for the deadletter queue as declared in [AMQP.Queue.declare/3](https://hexdocs.pm/amqp/AMQP.Queue.html#declare/3).
 
-  If argument 'x-expires' is given to arguments, then it will be used instead of `queue_ttl`.
-
-  If argument 'x-max-priority' is given to arguments, then it will be used instead of `queue_max_priority`.
-
   `deadletter_exchange` - name or `{type, name}` of the deadletter exchange (**Default:** Same as exchange name suffixed by `.deadletter`).
   If it does not exist, it will be created. For valid exchange types see `GenRMQ.Binding`
 
@@ -121,11 +99,9 @@ defmodule GenRMQ.Consumer do
       exchange: "gen_rmq_exchange",
       routing_key: "#",
       prefetch_count: "10",
-      uri: "amqp://guest:guest@localhost:5672",
       concurrency: true,
       terminate_timeout: 5_000,
       handle_message_timeout: 5_000,
-      queue_ttl: 5_000,
       retry_delay_function: fn attempt -> :timer.sleep(1000 * attempt) end,
       reconnect: true,
       deadletter: true,
@@ -136,8 +112,7 @@ defmodule GenRMQ.Consumer do
         ]
       ]
       deadletter_exchange: "gen_rmq_exchange.deadletter",
-      deadletter_routing_key: "#",
-      queue_max_priority: 10
+      deadletter_routing_key: "#"
     ]
   end
   ```
@@ -150,19 +125,16 @@ defmodule GenRMQ.Consumer do
               exchange: GenRMQ.Binding.exchange(),
               routing_key: [String.t()] | String.t(),
               prefetch_count: String.t(),
-              uri: String.t(),
               concurrency: boolean,
               terminate_timeout: integer,
               handle_message_timeout: integer,
-              queue_ttl: integer,
               retry_delay_function: function,
               reconnect: boolean,
               deadletter: boolean,
               deadletter_queue: String.t(),
               deadletter_queue_options: keyword,
               deadletter_exchange: GenRMQ.Binding.exchange(),
-              deadletter_routing_key: String.t(),
-              queue_max_priority: integer
+              deadletter_routing_key: String.t()
             ]
 
   @doc """
@@ -513,7 +485,7 @@ defmodule GenRMQ.Consumer do
 
     config
     |> Keyword.put(:queue, QueueConfiguration.setup(queue_name, config))
-    |> Keyword.put(:connection, Keyword.get(config, :connection, config[:uri]))
+    |> Keyword.put(:connection, Keyword.get(config, :connection))
   end
 
   defp handle_message(message, %{module: module, task_supervisor: task_supervisor_pid})

--- a/lib/gen_rmq/consumer/queue_configuration.ex
+++ b/lib/gen_rmq/consumer/queue_configuration.ex
@@ -7,8 +7,6 @@ defmodule GenRMQ.Consumer.QueueConfiguration do
   with respect to the consumer configuration API.
   """
 
-  @max_priority 255
-
   def setup(queue_name, config) do
     exchange = GenRMQ.Binding.exchange_name(config[:exchange])
     options = options(:queue_options, config)
@@ -48,33 +46,8 @@ defmodule GenRMQ.Consumer.QueueConfiguration do
     create_dead_letter = dead_letter[:create]
 
     options
-    |> setup_ttl()
-    |> setup_priority()
     |> setup_dead_letter_exchange(dead_letter, create_dead_letter)
     |> setup_dead_letter_routing_key(dead_letter, create_dead_letter)
-  end
-
-  defp setup_ttl(options) do
-    case options[:ttl] do
-      nil ->
-        options
-
-      value ->
-        args = Keyword.get(options, :arguments, [])
-        Keyword.put(options, :arguments, [{"x-expires", :long, value} | args])
-    end
-  end
-
-  defp setup_priority(options) do
-    case options[:max_priority] do
-      nil ->
-        options
-
-      value ->
-        value = set_max_priority_to_highest_value(value)
-        args = Keyword.get(options, :arguments, [])
-        Keyword.put(options, :arguments, [{"x-max-priority", :long, value} | args])
-    end
   end
 
   defp setup_dead_letter_exchange(options, _dead_letter, nil), do: options
@@ -108,11 +81,4 @@ defmodule GenRMQ.Consumer.QueueConfiguration do
         options
     end
   end
-
-  defp set_max_priority_to_highest_value(mp)
-       when is_integer(mp) and mp > @max_priority do
-    255
-  end
-
-  defp set_max_priority_to_highest_value(mp) when is_integer(mp), do: mp
 end

--- a/lib/gen_rmq/consumer/queue_configuration.ex
+++ b/lib/gen_rmq/consumer/queue_configuration.ex
@@ -25,25 +25,17 @@ defmodule GenRMQ.Consumer.QueueConfiguration do
   end
 
   defp options(queue_opts_word, config) do
-    [
-      durable: true
-    ]
-    |> Keyword.merge(Keyword.get(config, queue_opts_word, []))
+    provided_config = Keyword.get(config, queue_opts_word, [])
+    Keyword.merge([durable: true], provided_config)
   end
 
   defp return(name, options, dead_letter) do
     # dead_letter_options and options variables can contain
     # queue declare options as defined in
     # https://hexdocs.pm/amqp/AMQP.Queue.html#declare/3
-    dead_letter_options =
-      dead_letter[:options]
-      |> build_arguments()
-
+    dead_letter_options = dead_letter[:options] |> build_arguments()
     dead_letter = Keyword.put(dead_letter, :options, dead_letter_options)
-
-    options =
-      options
-      |> build_arguments(dead_letter)
+    options = options |> build_arguments(dead_letter)
 
     %{
       name: name,

--- a/test/gen_rmq/consumer/queue_configuration_test.exs
+++ b/test/gen_rmq/consumer/queue_configuration_test.exs
@@ -227,7 +227,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         arguments: [
           {"x-queue-type", :longstr, "quorum"},
           {"x-expires", :long, 42},
-          {"x-max-priority", :long, 1234}
+          {"x-max-priority", :long, 64}
         ]
       ],
       deadletter_queue_options: [
@@ -251,15 +251,15 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
     expected_conf = %{
       dead_letter: [
         options: [
-          durable: false,
-          auto_delete: true,
-          passive: false,
-          no_wait: false,
           arguments: [
             {"x-queue-type", :longstr, "quorum"},
             {"x-expires", :long, 42},
             {"x-max-priority", :long, 64}
-          ]
+          ],
+          durable: false,
+          auto_delete: true,
+          passive: false,
+          no_wait: false
         ],
         create: true,
         name: "#{name}_error",
@@ -273,12 +273,46 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
           {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"},
           {"x-queue-type", :longstr, "quorum"},
           {"x-expires", :long, 42},
-          {"x-max-priority", :long, 1234}
+          {"x-max-priority", :long, 64}
         ],
         durable: true,
         auto_delete: true,
         passive: true,
         no_wait: true
+      ]
+    }
+
+    qc = QueueConfiguration.setup(name, config)
+
+    assert expected_conf == qc
+  end
+
+  test "queue setup with x-max-priority over 255 is set to 255" do
+    name = "some_queue_name"
+
+    config = [
+      deadletter: false,
+      queue_options: [
+        arguments: [
+          {"x-max-priority", :long, 1000}
+        ]
+      ]
+    ]
+
+    expected_conf = %{
+      name: "some_queue_name",
+      options: [
+        arguments: [
+          {"x-max-priority", :long, 255}
+        ],
+        durable: true
+      ],
+      dead_letter: [
+        options: [durable: true],
+        create: false,
+        name: "some_queue_name_error",
+        exchange: ".deadletter",
+        routing_key: "#"
       ]
     }
 

--- a/test/gen_rmq/consumer/queue_configuration_test.exs
+++ b/test/gen_rmq/consumer/queue_configuration_test.exs
@@ -64,13 +64,11 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
     assert expected_conf == qc
   end
 
-  test "queue setup with ttl and priority returns correct configuration" do
+  test "queue without any queue options returns correct configuration" do
     name = "some_queue_name"
 
     config = [
       queue: name,
-      queue_ttl: 300,
-      queue_max_priority: 64,
       exchange: "example_exchange",
       routing_key: "routing_key.#",
       prefetch_count: "10",
@@ -80,10 +78,6 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
     expected_conf = %{
       dead_letter: [
         options: [
-          arguments: [
-            {"x-max-priority", :long, config[:queue_max_priority]},
-            {"x-expires", :long, config[:queue_ttl]}
-          ],
           durable: true
         ],
         create: true,
@@ -94,9 +88,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
       name: name,
       options: [
         arguments: [
-          {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"},
-          {"x-max-priority", :long, config[:queue_max_priority]},
-          {"x-expires", :long, config[:queue_ttl]}
+          {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"}
         ],
         durable: true
       ]
@@ -112,8 +104,6 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
 
     config = [
       queue: name,
-      queue_ttl: 300,
-      queue_max_priority: 64,
       queue_options: [
         durable: false,
         auto_delete: true,
@@ -122,7 +112,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         arguments: [
           {"x-queue-type", :longstr, "quorum"},
           {"x-expires", :long, 42},
-          {"x-max-priority", :long, 1234}
+          {"x-max-priority", :long, 10}
         ]
       ],
       exchange: "example_exchange",
@@ -134,10 +124,6 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
     expected_conf = %{
       dead_letter: [
         options: [
-          arguments: [
-            {"x-max-priority", :long, 64},
-            {"x-expires", :long, 300}
-          ],
           durable: true
         ],
         create: true,
@@ -151,7 +137,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
           {"x-dead-letter-exchange", :longstr, "#{config[:exchange]}.deadletter"},
           {"x-queue-type", :longstr, "quorum"},
           {"x-expires", :long, 42},
-          {"x-max-priority", :long, 1234}
+          {"x-max-priority", :long, 10}
         ],
         durable: false,
         auto_delete: true,
@@ -233,8 +219,6 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
 
     config = [
       queue: name,
-      queue_ttl: 300,
-      queue_max_priority: 64,
       queue_options: [
         durable: true,
         auto_delete: true,
@@ -253,7 +237,8 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
         no_wait: false,
         arguments: [
           {"x-queue-type", :longstr, "quorum"},
-          {"x-expires", :long, 42}
+          {"x-expires", :long, 42},
+          {"x-max-priority", :long, 64}
         ]
       ],
       deadletter_routing_key: "rk",
@@ -266,15 +251,15 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
     expected_conf = %{
       dead_letter: [
         options: [
-          arguments: [
-            {"x-max-priority", :long, 64},
-            {"x-queue-type", :longstr, "quorum"},
-            {"x-expires", :long, 42}
-          ],
           durable: false,
           auto_delete: true,
           passive: false,
-          no_wait: false
+          no_wait: false,
+          arguments: [
+            {"x-queue-type", :longstr, "quorum"},
+            {"x-expires", :long, 42},
+            {"x-max-priority", :long, 64}
+          ]
         ],
         create: true,
         name: "#{name}_error",

--- a/test/gen_rmq/consumer/queue_configuration_test.exs
+++ b/test/gen_rmq/consumer/queue_configuration_test.exs
@@ -64,7 +64,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
     assert expected_conf == qc
   end
 
-  test "queue without any queue options returns correct configuration" do
+  test "queue setup without any queue options returns correct configuration" do
     name = "some_queue_name"
 
     config = [
@@ -214,7 +214,7 @@ defmodule GenRMQ.Consumer.QueueConfigurationTest do
     assert expected_conf == qc
   end
 
-  test "queue setup with deal_letter_queue_options returns correct configuration" do
+  test "queue setup with dead letter queue_options returns correct configuration" do
     name = "some_queue_name"
 
     config = [

--- a/test/gen_rmq_consumer_test.exs
+++ b/test/gen_rmq_consumer_test.exs
@@ -67,15 +67,15 @@ defmodule GenRMQ.ConsumerTest do
     test "should close connection after normal termination", %{consumer: consumer_pid, state: state} do
       Consumer.stop(consumer_pid, :normal)
 
-      assert_receive({:EXIT, ^consumer_pid, :normal})
-      assert Process.alive?(state.conn.pid) == false
+      assert_receive({:EXIT, ^consumer_pid, :normal}, 5000)
+      Assert.repeatedly(fn -> assert Process.alive?(state.conn.pid) == false end)
     end
 
     test "should close connection after abnormal termination", %{consumer: consumer_pid, state: state} do
       Consumer.stop(consumer_pid, :unexpected_reason)
 
-      assert_receive({:EXIT, ^consumer_pid, :unexpected_reason})
-      assert Process.alive?(state.conn.pid) == false
+      assert_receive({:EXIT, ^consumer_pid, :unexpected_reason}, 5000)
+      Assert.repeatedly(fn -> assert Process.alive?(state.conn.pid) == false end)
     end
   end
 

--- a/test/support/test_consumers.ex
+++ b/test/support/test_consumers.ex
@@ -490,7 +490,7 @@ defmodule TestConsumer do
         queue: "gen_rmq_in_queue_" <> existing_exchange(),
         exchange: existing_exchange(),
         prefetch_count: "10",
-        uri: "amqp://guest:guest@localhost:5672",
+        connection: "amqp://guest:guest@localhost:5672",
         queue_ttl: 1_000
       ]
     end

--- a/test/support/test_consumers.ex
+++ b/test/support/test_consumers.ex
@@ -1,17 +1,32 @@
 defmodule TestConsumer do
+  def common_config() do
+    [
+      queue: "gen_rmq_in_queue",
+      exchange: "gen_rmq_in_exchange",
+      routing_key: "#",
+      prefetch_count: "10",
+      connection: "amqp://guest:guest@localhost:5672",
+      queue_options: [
+        arguments: [
+          {"x-expires", :long, 1_000}
+        ]
+      ],
+      deadletter_queue_options: [
+        arguments: [
+          {"x-expires", :long, 1_000}
+        ]
+      ]
+    ]
+  end
+
+  def config(config), do: Keyword.merge(common_config(), config)
+
   defmodule Default do
     @moduledoc false
     @behaviour GenRMQ.Consumer
 
     def init() do
-      [
-        queue: "gen_rmq_in_queue",
-        exchange: "gen_rmq_in_exchange",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000
-      ]
+      [] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -39,14 +54,10 @@ defmodule TestConsumer do
 
     def init() do
       [
-        queue: "gen_rmq_in_queue",
-        exchange: "gen_rmq_in_exchange",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        concurrency: false,
-        queue_ttl: 1_000
-      ]
+        queue: "gen_rmq_in_queue_no_concurrency",
+        exchange: "gen_rmq_in_exchange_no_concurrency",
+        concurrency: false
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -80,12 +91,8 @@ defmodule TestConsumer do
       [
         queue: "error_no_concurrency_queue",
         exchange: "error_no_concurrency_exchange",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        concurrency: false,
-        queue_ttl: 1_000
-      ]
+        concurrency: false
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -120,12 +127,8 @@ defmodule TestConsumer do
       [
         queue: "does_not_matter_queue",
         exchange: "does_not_matter_exchange",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        reconnect: false,
-        queue_ttl: 1_000
-      ]
+        reconnect: false
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -148,12 +151,8 @@ defmodule TestConsumer do
       [
         queue: "gen_rmq_in_queue_no_deadletter",
         exchange: "gen_rmq_in_exchange_no_deadletter",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000,
         deadletter: false
-      ]
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -183,9 +182,6 @@ defmodule TestConsumer do
           ]
         ],
         exchange: "gen_rmq_in_exchange_queue_options",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
         deadletter_queue: "dl_queue_options",
         deadletter_queue_options: [
           durable: false,
@@ -195,7 +191,7 @@ defmodule TestConsumer do
         ],
         deadletter_exchange: "dl_exchange_options",
         deadletter_routing_key: "dl_routing_key_options"
-      ]
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -225,14 +221,10 @@ defmodule TestConsumer do
       [
         queue: "gen_rmq_in_queue_custom_deadletter",
         exchange: "gen_rmq_in_exchange_custom_deadletter",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000,
         deadletter_queue: "dl_queue",
         deadletter_exchange: "dl_exchange",
         deadletter_routing_key: "dl_routing_key"
-      ]
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -256,14 +248,10 @@ defmodule TestConsumer do
       [
         queue: "gen_rmq_in_queue_custom_fanout_deadletter",
         exchange: "gen_rmq_in_exchange_custom_deadletter",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000,
         deadletter_queue: "dl_queue",
         deadletter_exchange: {:fanout, "dl_fanout_exchange"},
         deadletter_routing_key: "dl_routing_key"
-      ]
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -287,12 +275,13 @@ defmodule TestConsumer do
       [
         queue: "gen_rmq_in_queue_with_prio",
         exchange: "gen_rmq_in_exchange_with_prio",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000,
-        queue_max_priority: 100
-      ]
+        queue_options: [
+          arguments: [
+            {"x-expires", :long, 1_000},
+            {"x-max-priority", :long, 100}
+          ]
+        ]
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -317,12 +306,8 @@ defmodule TestConsumer do
     def init() do
       [
         queue: "gen_rmq_wt_in_queue",
-        exchange: {:topic, "gen_rmq_in_wt_exchange"},
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000
-      ]
+        exchange: {:topic, "gen_rmq_in_wt_exchange"}
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -351,12 +336,8 @@ defmodule TestConsumer do
     def init() do
       [
         queue: "gen_rmq_wd_in_queue",
-        exchange: {:direct, "gen_rmq_in_wd_exchange"},
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000
-      ]
+        exchange: {:direct, "gen_rmq_in_wd_exchange"}
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -385,16 +366,12 @@ defmodule TestConsumer do
     def init() do
       [
         queue: "gen_rmq_wf_in_queue",
-        exchange: {:fanout, "gen_rmq_in_wf_exchange"},
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000
-      ]
+        exchange: {:fanout, "gen_rmq_in_wf_exchange"}
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
-      "TestConsumer.WithDirectExchange"
+      "TestConsumer.WithFanoutExchange"
     end
 
     def handle_message(%GenRMQ.Message{payload: "\"reject\""} = message) do
@@ -420,11 +397,8 @@ defmodule TestConsumer do
       [
         queue: "gen_rmq_mb_in_queue",
         exchange: {:direct, "gen_rmq_in_mb_exchange"},
-        routing_key: ["routing_key_1", "routing_key_2"],
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000
-      ]
+        routing_key: ["routing_key_1", "routing_key_2"]
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -453,11 +427,8 @@ defmodule TestConsumer do
     def init() do
       [
         queue: "gen_rmq_with_default_exchange",
-        exchange: :default,
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000
-      ]
+        exchange: :default
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -488,11 +459,8 @@ defmodule TestConsumer do
     def init() do
       [
         queue: "gen_rmq_in_queue_" <> existing_exchange(),
-        exchange: existing_exchange(),
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000
-      ]
+        exchange: existing_exchange()
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -515,11 +483,8 @@ defmodule TestConsumer do
         queue: "gen_rmq_in_queue_options_no_args",
         queue_options: [durable: true],
         exchange: {:topic, "gen_rmq_in_exchange_queue_options_no_args"},
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
         deadletter: false
-      ]
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -554,12 +519,8 @@ defmodule TestConsumer do
     def init() do
       [
         queue: "gen_rmq_error_in_consume_queue",
-        exchange: "gen_rmq_error_in_consume_exchange",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 1_000
-      ]
+        exchange: "gen_rmq_error_in_consume_exchange"
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do
@@ -599,12 +560,8 @@ defmodule TestConsumer do
       [
         queue: "slow_consumer_queue",
         exchange: "slow_consumer_exchange",
-        routing_key: "#",
-        prefetch_count: "10",
-        connection: "amqp://guest:guest@localhost:5672",
-        queue_ttl: 5_000,
         handle_message_timeout: 500
-      ]
+      ] |> TestConsumer.config()
     end
 
     def consumer_tag() do


### PR DESCRIPTION
* Remove support for `uri` config option - replaced by `connection`
* Remove support for `queue_ttl` - replaced by `queue_options.arguments`
* Remove support for `queue_max_priority` - replaced by `queue_options.arguments`
* Remove all unsupported config options from guides, examples and documentation

Issues addressed:
* https://github.com/meltwater/gen_rmq/issues/220
* https://github.com/meltwater/gen_rmq/issues/219
* https://github.com/meltwater/gen_rmq/issues/218

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
