### PR TITLE
Change unix precision to seconds for timestamp property

### DIFF
--- a/lib/publisher.ex
+++ b/lib/publisher.ex
@@ -392,7 +392,7 @@ defmodule GenRMQ.Publisher do
 
   defp base_metadata(config) do
     [
-      timestamp: DateTime.to_unix(DateTime.utc_now(), :millisecond),
+      timestamp: DateTime.to_unix(DateTime.utc_now(), :second),
       app_id: config |> app_id() |> Atom.to_string(),
       content_type: "application/json"
     ]


### PR DESCRIPTION
The timestamp property in AMQP 0-9-1 is defined as a 64bit Unix timestamp, which is seconds since 1970/1/1
For reference -> https://github.com/rabbitmq/rabbitmq-message-timestamp/issues/16#issuecomment-314799434

This causes issues while reading in some of the client libraries which assume that the value is in seconds & parses this value incorrectly
Example, java client library -> https://github.com/rabbitmq/rabbitmq-java-client/blob/23e7ba0e96d383c80f8da2fb23786a1111854f9a/src/main/java/com/rabbitmq/client/impl/ValueReader.java#L266

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->
<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
