### PR TITLE
Add headers exchange type

### DIFF
--- a/lib/binding.ex
+++ b/lib/binding.ex
@@ -45,8 +45,12 @@ defmodule GenRMQ.Binding do
     Exchange.topic(chan, exchange, durable: true)
   end
 
+  def declare_exchange(chan, {:headers, exchange}) do
+    Exchange.fanout(chan, exchange, durable: true)
+  end
+
   def declare_exchange(chan, exchange) do
-    Exchange.topic(chan, exchange, durable: true)
+    Exchange.declare(chan, exchange, :headers, durable: true)
   end
 
   def exchange_name(:default) do

--- a/lib/binding.ex
+++ b/lib/binding.ex
@@ -46,7 +46,7 @@ defmodule GenRMQ.Binding do
   end
 
   def declare_exchange(chan, {:headers, exchange}) do
-    Exchange.fanout(chan, exchange, durable: true)
+    Exchange.declare(chan, exchange, :headers, durable: true)
   end
 
   def declare_exchange(chan, exchange) do

--- a/lib/binding.ex
+++ b/lib/binding.ex
@@ -5,7 +5,7 @@ defmodule GenRMQ.Binding do
   """
 
   @type exchange :: String.t() | {exchange_kind(), String.t()} | :default
-  @type exchange_kind :: :topic | :direct | :fanout
+  @type exchange_kind :: :topic | :direct | :fanout | :headers
 
   use AMQP
 
@@ -47,6 +47,10 @@ defmodule GenRMQ.Binding do
 
   def declare_exchange(chan, {:headers, exchange}) do
     Exchange.declare(chan, exchange, :headers, durable: true)
+  end
+
+  def declare_exchange(chan, {type, exchange}) when is_atom(type) do
+    Exchange.declare(chan, exchange, type, durable: true)
   end
 
   def declare_exchange(chan, exchange) do

--- a/lib/binding.ex
+++ b/lib/binding.ex
@@ -50,7 +50,7 @@ defmodule GenRMQ.Binding do
   end
 
   def declare_exchange(chan, exchange) do
-    Exchange.declare(chan, exchange, :headers, durable: true)
+    Exchange.topic(chan, exchange, durable: true)
   end
 
   def exchange_name(:default) do


### PR DESCRIPTION
Adds headers exchange type when declaring an exchange

## Description

GenRMQ currently supports the 3 predefined exchange types on AMPQ, but its missing the "headers" exchange type. This  PR adds 

## Checklist

- [] I have added unit tests to cover my changes.
- [] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [] I have updated the documentation accordingly
