### PR TITLE
Support declaring non-standard exchange types

### DIFF
--- a/lib/binding.ex
+++ b/lib/binding.ex
@@ -45,6 +45,10 @@ defmodule GenRMQ.Binding do
     Exchange.topic(chan, exchange, durable: true)
   end
 
+  def declare_exchange(chan, {type, exchange}) do
+    Exchange.declare(chan, exchange, type, durable: true)
+  end
+
   def declare_exchange(chan, exchange) do
     Exchange.topic(chan, exchange, durable: true)
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With this change the library will allow declaring non-standard exchange types, such as provided by plugins.

## Description
<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
Currently there's no way to define non-standard exchange type. AMQP library allows that via `Exchange.declare`
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Include examples on how to use the functionality if applicable -->
<!--- Describe any manual or special tests you have done -->

<!--- Attach screenshots if appropriate -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Ignore the ones that are not applicable -->
- [ ] I have added unit tests to cover my changes.
- [ ] I have improved the code quality of this repo. (refactoring, or reduced number of static analyser issues)
- [ ] I have updated the documentation accordingly
